### PR TITLE
649: disconnect account security bugs

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/AccountSettingPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AccountSettingPresenter.kt
@@ -11,6 +11,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.addTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.concept.sync.Avatar
+import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.DialogAction
 import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.flux.Dispatcher

--- a/app/src/main/java/mozilla/lockbox/presenter/AccountSettingPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AccountSettingPresenter.kt
@@ -11,7 +11,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.addTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.concept.sync.Avatar
-import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.DialogAction
 import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.flux.Dispatcher

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -9,11 +9,9 @@ package mozilla.lockbox.store
 import android.content.Context
 import android.net.Uri
 import android.os.Looper
-import android.text.format.DateUtils
 import android.webkit.CookieManager
 import android.webkit.WebStorage
 import android.webkit.WebView
-import android.webkit.WebViewClient
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
@@ -44,8 +42,6 @@ import mozilla.lockbox.support.Optional
 import mozilla.lockbox.support.SecurePreferences
 import mozilla.lockbox.support.asOptional
 import java.io.File
-import java.lang.Exception
-import java.util.Date
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
@@ -69,7 +65,6 @@ open class AccountStore(
             )
         }
 
-    private lateinit var context: Context
     private val coroutineContext: CoroutineContext
         get() = Dispatchers.Default + exceptionHandler
 
@@ -89,8 +84,12 @@ open class AccountStore(
     private var fxa: FirefoxAccount? = null
 
     open val loginURL: Observable<String> = ReplaySubject.createWithSize(1)
+
     private val syncCredentials: Observable<Optional<SyncCredentials>> = ReplaySubject.createWithSize(1)
     open val profile: Observable<Optional<Profile>> = ReplaySubject.createWithSize(1)
+
+    private lateinit var webView: WebView
+    private lateinit var logDirectory: File
 
     init {
         val resetObservable = lifecycleStore.lifecycleEvents
@@ -123,9 +122,10 @@ open class AccountStore(
             .addTo(compositeDisposable)
     }
 
-    override fun injectContext(con: Context) {
-        context = con
+    override fun injectContext(context: Context) {
         detectAccount()
+        webView = WebView(context)
+        logDirectory = context.dataDir
     }
 
     private fun detectAccount() {
@@ -232,42 +232,30 @@ open class AccountStore(
 
         this.securePreferences.remove(Constant.Key.firefoxAccount)
         this.generateNewFirefoxAccount()
-
-        clearCaches()
+        webView.clearCache(true)
+        clearLogs()
     }
 
-    private fun clearCaches() {
-        // WebView.clearCache(true) in : /data/data/mozilla.lockbox/cache/org.chromium.android_webview/*
-        // LevelDB log files in : /data/data/mozilla.lockbox/app_webview/Local Storage/leveldb/[0-9]*.log
-
-        val context =
+    private fun clearLogs() {
         log.info("Starting cache prune.")
-        val numDeletedFiles = clearCacheFolder(context.getCacheDir())
+        val numDeletedFiles = clearLogFolder(logDirectory)
         log.info("Cache pruning completed, $numDeletedFiles files deleted.")
     }
 
-    // https://stackoverflow.com/questions/2465432/android-webview-completely-clear-the-cache
-    private fun clearCacheFolder(dir: File): Int {
-
+    private fun clearLogFolder(dir: File): Int {
         var deletedFiles = 0
-        if (dir != null && dir.isDirectory) {
+        if (dir.isDirectory) {
             try {
                 for (child in dir.listFiles()) {
-
-                    //first delete subdirectories recursively
                     if (child.isDirectory) {
-                        deletedFiles += clearCacheFolder(child)
+                        deletedFiles += clearLogFolder(child)
                     }
-
-                    //then delete the files and subdirectories in this dir
-                    //only empty directories can be deleted, so subdirs have been done first
                     if (child.delete()) {
                         deletedFiles++
                     }
                 }
-            }
-            catch(exception: Exception) {
-                log.error("Failed to clean the cache.", exception)
+            } catch (exception: Exception) {
+                log.error("Failed to clear the directory.", exception)
             }
         }
         return deletedFiles

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -237,9 +237,9 @@ open class AccountStore(
     }
 
     private fun clearLogs() {
-        log.info("Starting cache prune.")
+        log.info("Starting log prune.")
         val numDeletedFiles = clearLogFolder(logDirectory)
-        log.info("Cache pruning completed, $numDeletedFiles files deleted.")
+        log.info("Log pruning completed, $numDeletedFiles files deleted.")
     }
 
     private fun clearLogFolder(dir: File): Int {

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -12,11 +12,9 @@ import android.os.Looper
 import android.webkit.CookieManager
 import android.webkit.WebStorage
 import android.webkit.WebView
-import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
-import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.ReplaySubject
 import io.reactivex.subjects.Subject
 import kotlinx.coroutines.CoroutineExceptionHandler

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -12,9 +12,11 @@ import android.os.Looper
 import android.webkit.CookieManager
 import android.webkit.WebStorage
 import android.webkit.WebView
+import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
+import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.ReplaySubject
 import io.reactivex.subjects.Subject
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -232,8 +234,11 @@ open class AccountStore(
 
         this.securePreferences.remove(Constant.Key.firefoxAccount)
         this.generateNewFirefoxAccount()
+
         webView.clearCache(true)
         clearLogs()
+
+        dispatcher.dispatch(DataStoreAction.Reset)
     }
 
     private fun clearLogs() {

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -257,10 +257,10 @@ open class AccountStore(
                     }[0]
                     .listFiles()
 
-                for (logs in leveldbDir) {
-                    val logname = logs.name
+                for (file in leveldbDir) {
+                    val logname = file.name
                     if (logname.endsWith(".log")) {
-                        logs.delete()
+                        file.delete()
                     }
                 }
             } catch (exception: Exception) {


### PR DESCRIPTION
Fixes #649

- [x] delete local storage logs
- [x] delete webview caches
- [x] remove encryption key when disconnecting account
 
## Testing and Review Notes
**Note:** `getDir("..")` was not working to find the whole correct path to the logs, so I used this instead:
```
logDirectory = context.getDir("webview", Context.MODE_PRIVATE)
...
val leveldbDir = logDirectory.listFiles()
                    .filter { file ->
                        file.name.startsWith("Local")
                    }[0]
                    .listFiles()
                    .filter { file ->
                        file.name.startsWith("leveldb")
                    }[0]
                    .listFiles()
```

Steps to reproduce (from the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1548361))

1. Sign in to Lockbox with a valid Firefox user account
2. Disconnect from the application by using Account > “Disconnect Firefox Lockbox”;
3. Confirm the decision on the prompted dialog;
4. Inspect the following paths, reviewing each file content with e.g. xxd:
   * /data/data/mozilla.lockbox/app_webview/Local Storage/leveldb/[0-9]*.log
   * /data/data/mozilla.lockbox/cache/org.chromium.android_webview/*

## Screenshots or Videos

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)

