### PR TITLE
close db when going to the background

### DIFF
--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -112,7 +112,13 @@ open class DataStore(
     }
 
     private fun shutdown() {
-        this.backend?.close()
+        // rather than calling `close`, which will make the `AsyncLoginsStorage` instance unusable,
+        // we use the `ensureLocked` method to close the database connection.
+        val backend = this.backend ?: return notReady()
+        backend.ensureLocked()
+            .asSingle(coroutineContext)
+            .subscribe()
+            .addTo(compositeDisposable)
     }
 
     private fun setupAutoLock() {

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -240,6 +240,7 @@ class DataStoreTest : DisposingTest() {
 
         (lifecycleStore.lifecycleEvents as Subject).onNext(LifecycleAction.Background)
         verify(autoLockSupport).storeNextAutoLockTime()
+        verify(support.storage).close()
     }
 
     @Test
@@ -258,6 +259,7 @@ class DataStoreTest : DisposingTest() {
 
         (lifecycleStore.lifecycleEvents as Subject).onNext(LifecycleAction.Background)
         verify(autoLockSupport, never()).storeNextAutoLockTime()
+        verify(support.storage).close()
     }
 
     @Test
@@ -283,8 +285,11 @@ class DataStoreTest : DisposingTest() {
 
         dispatcher.dispatch(DataStoreAction.Unlock)
         Assert.assertEquals(State.Unlocked, stateIterator.next())
+        clearInvocations(support.storage)
         autoLockSupport.shouldLockStub = false
         (lifecycleStore.lifecycleEvents as Subject).onNext(LifecycleAction.Foreground)
+        Assert.assertEquals(State.Unlocked, stateIterator.next())
+        verify(support.storage).ensureUnlocked(support.encryptionKey)
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -240,7 +240,7 @@ class DataStoreTest : DisposingTest() {
 
         (lifecycleStore.lifecycleEvents as Subject).onNext(LifecycleAction.Background)
         verify(autoLockSupport).storeNextAutoLockTime()
-        verify(support.storage).close()
+        verify(support.storage).ensureLocked()
     }
 
     @Test
@@ -256,10 +256,11 @@ class DataStoreTest : DisposingTest() {
         dispatcher.dispatch(DataStoreAction.Lock)
         verify(autoLockSupport).backdateNextLockTime()
         Assert.assertEquals(State.Locked, stateIterator.next())
+        clearInvocations(support.storage)
 
         (lifecycleStore.lifecycleEvents as Subject).onNext(LifecycleAction.Background)
         verify(autoLockSupport, never()).storeNextAutoLockTime()
-        verify(support.storage).close()
+        verify(support.storage).ensureLocked()
     }
 
     @Test


### PR DESCRIPTION
Fixes #684 

## Testing and Review Notes
This ticket impacts both foregrounding and backgrounding datastore interactions. Make sure that putting the app in the background and returning to it behaves as you would expect.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
