### PR TITLE
625: IllegalStateException - At least one fingerprint must be enrolled

### DIFF
--- a/app/src/main/java/mozilla/lockbox/store/FingerprintStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/FingerprintStore.kt
@@ -25,6 +25,7 @@ import mozilla.lockbox.R
 import mozilla.lockbox.action.FingerprintSensorAction
 import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
+import mozilla.lockbox.log
 import java.io.IOException
 import java.security.InvalidAlgorithmParameterException
 import java.security.InvalidKeyException
@@ -191,13 +192,16 @@ open class FingerprintStore(
                 init(builder.build())
                 generateKey()
             }
-        } catch (e: Exception) {
-            when (e) {
+        } catch (exception: Exception) {
+            when (exception) {
                 is NoSuchAlgorithmException,
-                is InvalidAlgorithmParameterException,
+                is InvalidAlgorithmParameterException -> {
+                    log.error("Unable to create keys. ", exception)
+                    throw exception
+                }
                 is CertificateException,
-                is IOException -> throw RuntimeException(e)
-                else -> throw e
+                is IOException -> throw RuntimeException(exception)
+                else -> throw exception
             }
         }
     }


### PR DESCRIPTION
Fixes #625

## Testing and Review Notes
This fix throws the `InvalidAlgorithmParameterException` error from 
```
keyGenerator.run {
      init(builder.build()) ... }
```
in the catch block and logs the error. Not sure how to explicitly test this. I'd love a second opinion  @sashei.

## Screenshots or Videos


## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
