### PR TITLE
648: Remove registered device from AS device list

### DIFF
--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -20,7 +20,6 @@ import io.reactivex.subjects.Subject
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asMaybe
 import kotlinx.coroutines.rx2.asSingle
 import mozilla.appservices.fxaclient.FxaException
@@ -243,8 +242,14 @@ open class AccountStore(
     }
 
     private fun removeDeviceFromFxA() {
-        runBlocking {
-            fxa?.deviceConstellation()?.destroyCurrentDeviceAsync()?.await()
+        if (fxa != null) {
+            fxa!!.deviceConstellation()
+                .destroyCurrentDeviceAsync()
+                .asSingle(coroutineContext)
+                .subscribe()
+                .addTo(compositeDisposable)
+        } else {
+            log.info("FxA is null. No devices to disconnect.")
         }
     }
 

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -243,17 +243,17 @@ open class AccountStore(
     }
 
     private fun removeDeviceFromFxA() {
-        if(fxa != null) {
-            val account = mozilla.appservices.fxaclient.FirefoxAccount.fromJSONString(fxa!!.toJSONString())
-            val registeredDevices = account.getDevices()
+        val account = mozilla.appservices.fxaclient.FirefoxAccount
+            .fromJSONString(
+                fxa?.toJSONString() ?: ""
+            )
+        
+        val registeredDevices = account.getDevices()
 
-            for (device in registeredDevices) {
-                if(device.isCurrentDevice) {
-                    account.destroyDevice(device.id)
-                }
+        for (device in registeredDevices) {
+            if(device.isCurrentDevice) {
+                account.destroyDevice(device.id)
             }
-        } else {
-            log.info("FxA is null. ")
         }
     }
 

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -20,6 +20,7 @@ import io.reactivex.subjects.Subject
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.rx2.asMaybe
 import kotlinx.coroutines.rx2.asSingle
 import mozilla.appservices.fxaclient.FxaException
@@ -242,17 +243,8 @@ open class AccountStore(
     }
 
     private fun removeDeviceFromFxA() {
-        val account = mozilla.appservices.fxaclient.FirefoxAccount
-            .fromJSONString(
-                fxa?.toJSONString() ?: ""
-            )
-
-        val registeredDevices = account.getDevices()
-
-        for (device in registeredDevices) {
-            if (device.isCurrentDevice) {
-                account.destroyDevice(device.id)
-            }
+        runBlocking {
+            fxa?.deviceConstellation()?.destroyCurrentDeviceAsync()?.await()
         }
     }
 

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -229,6 +229,8 @@ open class AccountStore(
     }
 
     private fun clear() {
+        removeDeviceFromFxA()
+
         if (Looper.myLooper() != null) {
             CookieManager.getInstance().removeAllCookies { }
             WebStorage.getInstance().deleteAllData()
@@ -239,7 +241,6 @@ open class AccountStore(
 
         webView.clearCache(true)
         clearLogs()
-        removeDeviceFromFxA()
     }
 
     private fun removeDeviceFromFxA() {
@@ -247,7 +248,7 @@ open class AccountStore(
             .fromJSONString(
                 fxa?.toJSONString() ?: ""
             )
-        
+
         val registeredDevices = account.getDevices()
 
         for (device in registeredDevices) {

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -28,6 +28,8 @@ import mozilla.components.concept.sync.Avatar
 import mozilla.components.concept.sync.Profile
 import mozilla.components.service.fxa.Config
 import mozilla.components.service.fxa.FirefoxAccount
+import mozilla.components.service.fxa.FxaDeviceConstellation
+import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
@@ -237,8 +239,22 @@ open class AccountStore(
 
         webView.clearCache(true)
         clearLogs()
+        removeDeviceFromFxA()
+    }
 
-        dispatcher.dispatch(DataStoreAction.Reset)
+    private fun removeDeviceFromFxA() {
+        if(fxa != null) {
+            val account = mozilla.appservices.fxaclient.FirefoxAccount.fromJSONString(fxa!!.toJSONString())
+            val registeredDevices = account.getDevices()
+
+            for (device in registeredDevices) {
+                if(device.isCurrentDevice) {
+                    account.destroyDevice(device.id)
+                }
+            }
+        } else {
+            log.info("FxA is null. ")
+        }
     }
 
     private fun clearLogs() {

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -28,8 +28,6 @@ import mozilla.components.concept.sync.Avatar
 import mozilla.components.concept.sync.Profile
 import mozilla.components.service.fxa.Config
 import mozilla.components.service.fxa.FirefoxAccount
-import mozilla.components.service.fxa.FxaDeviceConstellation
-import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
@@ -252,7 +250,7 @@ open class AccountStore(
         val registeredDevices = account.getDevices()
 
         for (device in registeredDevices) {
-            if(device.isCurrentDevice) {
+            if (device.isCurrentDevice) {
                 account.destroyDevice(device.id)
             }
         }

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
@@ -37,7 +37,6 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.Mockito
-import org.mockito.Mockito.anyString
 import org.mockito.Mockito.clearInvocations
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
@@ -231,7 +230,7 @@ class ItemDetailPresenterTest {
             )
         )
 
-        Assert.assertEquals(R.string.toast_username_copied, view.toastNotificationArgument)
+        assertEquals(R.string.toast_username_copied, view.toastNotificationArgument)
     }
 
     @Test
@@ -244,7 +243,7 @@ class ItemDetailPresenterTest {
             emptyList()
         )
 
-        Assert.assertEquals(null, view.toastNotificationArgument)
+        assertEquals(null, view.toastNotificationArgument)
     }
 
     @Test
@@ -260,7 +259,7 @@ class ItemDetailPresenterTest {
             )
         )
 
-        Assert.assertEquals(R.string.toast_password_copied, view.toastNotificationArgument)
+        assertEquals(R.string.toast_password_copied, view.toastNotificationArgument)
     }
 
     @Test


### PR DESCRIPTION
Fixes #648

## Testing and Review Notes
This implementation parses the Fx Account into the application services Fx Account, which contains the list of devices that are associated with that account. From there, we can find the current device and remove it from the list. 

## Screenshots or Videos

## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] ~add unit tests~
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
