### PR TITLE
fix uiTests failures

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/robots/DisconnectDisclaimerRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/DisconnectDisclaimerRobot.kt
@@ -14,7 +14,8 @@ import mozilla.lockbox.R
 class DisconnectDisclaimerRobot : BaseTestRobot {
     override fun exists() = displayed { text(R.string.disconnect) }
 
-    fun tapDisconnect() = click { text(R.string.disconnect) }
+    fun tapDisconnect() = click { text("Disconnect Lockwise") }
+    fun acceptDisconnect() = click { text("Disconnect") }
 
     fun cancel() = click { text(R.string.cancel) }
 }

--- a/app/src/androidTest/java/mozilla/lockbox/uiTests/OnboardingTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/uiTests/OnboardingTest.kt
@@ -28,7 +28,11 @@ open class OnboardingTest {
 
     @Before
     fun setUp() {
-        navigator.disconnectAccount()
+        navigator.gotoAccountSetting()
+        disconnectDisclaimer {
+            tapDisconnect()
+            acceptDisconnect()
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/mozilla/lockbox/uiTests/OnboardingTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/uiTests/OnboardingTest.kt
@@ -7,6 +7,7 @@ import mozilla.lockbox.robots.autofillOnboardingScreen
 import mozilla.lockbox.robots.fingerprintOnboardingScreen
 import mozilla.lockbox.robots.fxaLogin
 import mozilla.lockbox.robots.onboardingConfirmationScreen
+import mozilla.lockbox.robots.disconnectDisclaimer
 import mozilla.lockbox.store.FingerprintStore
 import mozilla.lockbox.store.SettingStore
 import mozilla.lockbox.view.RootActivity


### PR DESCRIPTION
Fixes #734

Tests were failing when running testOnboardingConfirmation.
Looks like the navigator.disconnect() is not working in the setUp, changing it to do the disconnect but step by step seems to work.

