### PR TITLE
Lockwise logo displayed underneath item list and nav drawer after foreground

### DIFF
--- a/app/src/main/res/layout/fragment_item_list.xml
+++ b/app/src/main/res/layout/fragment_item_list.xml
@@ -11,7 +11,8 @@
     android:id="@+id/appDrawer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".view.ItemListFragment">
+    tools:context=".view.ItemListFragment"
+    android:theme="@style/AppTheme">
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #698 
Fixes #699 

## Testing and Review Notes
See Andrei's video on #698 for a good look at what was happening. I am able to repro this consistently on my Pixel 3 with his steps, and explicitly setting the theme fixes this issue for both tickets.

## Screenshots or Videos


## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
