### PR TITLE
657: update ignored gradle dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,9 +84,9 @@ configurations.all { config ->
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0-alpha04'
+    implementation 'androidx.appcompat:appcompat:1.1.0-beta01'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0-alpha05'
+    implementation 'com.google.android.material:material:1.1.0-alpha07'
     implementation "androidx.recyclerview:recyclerview:$recyclerview_version"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.0.0'
@@ -118,8 +118,8 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.2'
     releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.2'
     testImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.2'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0-alpha04'
-    implementation 'androidx.lifecycle:lifecycle-common-java8:2.1.0-alpha04'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0-alpha01'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0-alpha01'
     implementation "android.arch.navigation:navigation-fragment:$navigation_version"
     implementation "android.arch.navigation:navigation-ui-ktx:$navigation_version"
     implementation 'com.adjust.sdk:adjust-android:4.17.0'
@@ -138,8 +138,8 @@ dependencies {
     androidTestImplementation "androidx.test:rules:$androidxTest_version"
     androidTestUtil "androidx.test:orchestrator:$androidxTest_version"
     androidTestImplementation 'org.mockito:mockito-android:2.22.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
     androidTestImplementation("androidx.test.espresso:espresso-contrib:3.1.1") {
         exclude group: 'com.android.support', module: 'appcompat'
         exclude group: 'com.android.support', module: 'support-v4'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,16 +84,12 @@ configurations.all { config ->
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    //noinspection GradleDependency
     implementation 'androidx.appcompat:appcompat:1.1.0-alpha04'
     implementation 'androidx.cardview:cardview:1.0.0'
-    //noinspection GradleDependency
     implementation 'com.google.android.material:material:1.1.0-alpha05'
-    //noinspection GradleDependency
     implementation "androidx.recyclerview:recyclerview:$recyclerview_version"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.0.0'
-    //noinspection GradleDependency
     implementation "androidx.constraintlayout:constraintlayout:${constraintlayout_version}"
     implementation "com.jakewharton.rxbinding2:rxbinding:${rxbinding_version}"
     implementation "com.jakewharton.rxbinding2:rxbinding-design-kotlin:${rxbinding_version}"
@@ -122,9 +118,7 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.2'
     releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.2'
     testImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.2'
-    //noinspection GradleDependency
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0-alpha04'
-    //noinspection GradleDependency
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.1.0-alpha04'
     implementation "android.arch.navigation:navigation-fragment:$navigation_version"
     implementation "android.arch.navigation:navigation-ui-ktx:$navigation_version"

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -62,7 +62,6 @@ abstract class RoutePresenter(
 
     private val onBackPressedDispatcher = activity.onBackPressedDispatcher
 
-    // enabled is defaulted to true. Do we want this?
     private val callback = BackPressedCallback(false, dispatcher)
 
     override fun onViewReady() {

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -54,7 +54,7 @@ abstract class RoutePresenter(
     class BackPressedCallback(
         val enabled: Boolean = false,
         val dispatcher: Dispatcher
-    ): OnBackPressedCallback(enabled) {
+    ) : OnBackPressedCallback(enabled) {
         override fun handleOnBackPressed() {
             dispatcher.dispatch(RouteAction.InternalBack)
         }

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -14,7 +14,6 @@ import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
-import androidx.arch.core.util.Cancellable
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavController
@@ -37,6 +36,7 @@ abstract class RoutePresenter(
     private val dispatcher: Dispatcher,
     private val routeStore: RouteStore
 ) : Presenter() {
+
     lateinit var navController: NavController
 
     open val navHostFragmentManager: FragmentManager
@@ -51,23 +51,33 @@ abstract class RoutePresenter(
             return navHostFragmentManager.fragments.lastOrNull()
         }
 
-    private val backListener = OnBackPressedCallback {
-        dispatcher.dispatch(RouteAction.InternalBack)
-        false
+    class BackPressedCallback(
+        val enabled: Boolean = false,
+        val dispatcher: Dispatcher
+    ): OnBackPressedCallback(enabled) {
+        override fun handleOnBackPressed() {
+            dispatcher.dispatch(RouteAction.InternalBack)
+        }
     }
 
-    private var backListenerCancellable: Cancellable? = null
+    private val onBackPressedDispatcher = activity.onBackPressedDispatcher
+
+    // enabled is defaulted to true. Do we want this?
+    private val callback = BackPressedCallback(false, dispatcher)
+
+    override fun onViewReady() {
+        super.onViewReady()
+        onBackPressedDispatcher.addCallback(activity, callback)
+    }
 
     override fun onPause() {
         super.onPause()
-        backListenerCancellable?.cancel()
-        backListenerCancellable = null
         compositeDisposable.clear()
     }
 
     override fun onResume() {
         super.onResume()
-        backListenerCancellable = activity.onBackPressedDispatcher.addCallback(activity, backListener)
+        onBackPressedDispatcher.addCallback(activity, callback)
     }
 
     protected abstract fun route(action: RouteAction)

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -6,9 +6,6 @@
 
 package mozilla.lockbox.store
 
-import android.content.Context
-import androidx.activity.OnBackPressedCallback
-import androidx.activity.OnBackPressedDispatcher
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.Relay
 import io.reactivex.Observable

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -40,7 +40,6 @@ open class RouteStore(
     private val onboarding: Observable<Boolean> = BehaviorRelay.createDefault(false)
     private val _routes = StackReplaySubject.create<RouteAction>()
     open val routes: Observable<RouteAction> = _routes
-    private val backPressedDispatcher = OnBackPressedDispatcher()
 
     init {
         dispatcher.register

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -6,6 +6,9 @@
 
 package mozilla.lockbox.store
 
+import android.content.Context
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.Relay
 import io.reactivex.Observable
@@ -37,6 +40,7 @@ open class RouteStore(
     private val onboarding: Observable<Boolean> = BehaviorRelay.createDefault(false)
     private val _routes = StackReplaySubject.create<RouteAction>()
     open val routes: Observable<RouteAction> = _routes
+    private val backPressedDispatcher = OnBackPressedDispatcher()
 
     init {
         dispatcher.register

--- a/app/src/test/java/mozilla/lockbox/presenter/AppRoutePresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AppRoutePresenterTest.kt
@@ -9,6 +9,7 @@ package mozilla.lockbox.presenter
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedDispatcher
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
@@ -59,11 +60,14 @@ class AppRoutePresenterTest {
     @Mock
     private val settingStore = Mockito.mock(SettingStore::class.java)
 
-    private val routeStub = PublishSubject.create<RouteAction>()
+    @Mock
+    val onBackPressedDispatcher: OnBackPressedDispatcher = Mockito.mock(OnBackPressedDispatcher::class.java)
+
     @Mock
     val routeStore = Mockito.mock(RouteStore::class.java)!!
 
     private val dispatcher = Dispatcher()
+    private val routeStub = PublishSubject.create<RouteAction>()
     private val dispatcherObserver = TestObserver.create<Action>()
 
     lateinit var subject: AppRoutePresenter
@@ -77,6 +81,7 @@ class AppRoutePresenterTest {
 
         PowerMockito.mockStatic(Navigation::class.java)
         PowerMockito.whenNew(RouteStore::class.java).withAnyArguments().thenReturn(routeStore)
+        PowerMockito.`when`(activity.onBackPressedDispatcher).thenReturn(onBackPressedDispatcher)
 
         subject = AppRoutePresenter(
             activity,

--- a/app/src/test/java/mozilla/lockbox/presenter/AutofillRoutePresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AutofillRoutePresenterTest.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import android.content.Intent
 import android.service.autofill.FillResponse
 import android.view.autofill.AutofillManager
+import androidx.activity.OnBackPressedDispatcher
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -50,7 +51,6 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.Mockito.any
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mock
@@ -107,16 +107,19 @@ class AutofillRoutePresenterTest {
     val intent: Intent = PowerMockito.mock(Intent::class.java)
 
     @Mock
-    val keyguardManager = Mockito.mock(KeyguardManager::class.java)!!
+    val keyguardManager = mock(KeyguardManager::class.java)!!
 
     @Mock
     val routeStore = PowerMockito.mock(RouteStore::class.java)!!
 
     @Mock
+    val onBackPressedDispatcher: OnBackPressedDispatcher = mock(OnBackPressedDispatcher::class.java)
+
+    @Mock
     val dataStore = PowerMockito.mock(DataStore::class.java)!!
 
-    val callingIntent = Intent()
-    val credentialIntent = Intent()
+    private val callingIntent = Intent()
+    private val credentialIntent = Intent()
 
     class FakeResponseBuilder : FillResponseBuilder(ParsedStructure(packageName = "meow")) {
         @Mock
@@ -142,8 +145,8 @@ class AutofillRoutePresenterTest {
         }
     }
 
-    val routeStub = PublishSubject.create<RouteAction>()
-    val stateStub = PublishSubject.create<DataStore.State>()
+    private val routeStub = PublishSubject.create<RouteAction>()
+    private val stateStub = PublishSubject.create<DataStore.State>()
 
     class FakeAutofillStore : AutofillStore() {
         val autofillActionStub = PublishSubject.create<AutofillAction>()
@@ -217,6 +220,7 @@ class AutofillRoutePresenterTest {
         whenCalled(navController.currentDestination).thenReturn(navDestination)
         PowerMockito.mockStatic(Navigation::class.java)
         whenCalled(Navigation.findNavController(activity, R.id.autofill_fragment_nav_host)).thenReturn(navController)
+        whenCalled(activity.onBackPressedDispatcher).thenReturn(onBackPressedDispatcher)
 
         subject = AutofillRoutePresenter(
             activity,

--- a/app/src/test/java/mozilla/lockbox/presenter/RoutePresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/RoutePresenterTest.kt
@@ -9,6 +9,7 @@ package mozilla.lockbox.presenter
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
+import androidx.activity.OnBackPressedDispatcher
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -30,6 +31,7 @@ import mozilla.lockbox.extensions.view.AlertDialogHelper
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.store.RouteStore
+import mozilla.lockbox.view.DialogFragment
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -76,29 +78,33 @@ class RoutePresenterTest {
     val navDestination: NavDestination = Mockito.mock(NavDestination::class.java)
 
     @Mock
-    val dialogFragment = Mockito.mock(mozilla.lockbox.view.DialogFragment::class.java)
+    val dialogFragment: DialogFragment = Mockito.mock(mozilla.lockbox.view.DialogFragment::class.java)
 
     @Mock
     val intent: Intent = PowerMockito.mock(Intent::class.java)
 
     @Mock
-    val settingIntent = Mockito.mock(SettingIntent.Security::class.java)
+    val settingIntent: SettingIntent = Mockito.mock(SettingIntent.Security::class.java)
 
     @Mock
-    val settingAction = Mockito.mock(RouteAction.SystemSetting::class.java)
+    val settingAction: RouteAction.SystemSetting = Mockito.mock(RouteAction.SystemSetting::class.java)
 
     @Mock
-    val action = Mockito.mock(Action::class.java)
+    val action: Action = Mockito.mock(Action::class.java)
 
     @Mock
-    val dialogHelper = Mockito.mock(AlertDialogHelper::class.java)
+    val dialogHelper: AlertDialogHelper = Mockito.mock(AlertDialogHelper::class.java)
 
     @Mock
-    val keyguardManager = Mockito.mock(KeyguardManager::class.java)
+    val keyguardManager: KeyguardManager = Mockito.mock(KeyguardManager::class.java)
 
-    val routeStub = PublishSubject.create<RouteAction>()
     @Mock
-    val routeStore = PowerMockito.mock(RouteStore::class.java)
+    val routeStore: RouteStore = PowerMockito.mock(RouteStore::class.java)
+
+    @Mock
+    val onBackPressedDispatcher = Mockito.mock(OnBackPressedDispatcher::class.java)
+
+    private val routeStub = PublishSubject.create<RouteAction>()
 
     private val immediate = object : Scheduler() {
         override fun scheduleDirect(
@@ -117,8 +123,8 @@ class RoutePresenterTest {
 
     private val dispatcher = Dispatcher()
     private val dispatcherObserver = TestObserver.create<Action>()
-    val callingIntent = Intent()
-    val credentialIntent = Intent()
+    private val callingIntent = Intent()
+    private val credentialIntent = Intent()
 
     lateinit var subject: RoutePresenter
 
@@ -157,7 +163,7 @@ class RoutePresenterTest {
         whenCalled(navDestination.id).thenReturn(R.id.fragment_null)
         whenCalled(navController.currentDestination).thenReturn(navDestination)
         whenCalled(routeStore.routes).thenReturn(routeStub)
-
+        whenCalled(activity.onBackPressedDispatcher).thenReturn(onBackPressedDispatcher)
         PowerMockito.mockStatic(Navigation::class.java)
         PowerMockito.mockStatic(AlertDialogHelper::class.java)
         PowerMockito.whenNew(Intent::class.java).withNoArguments()


### PR DESCRIPTION
Fixes #657

## Testing and Review Notes
Important changes:
* `androidx.arch.core.util.Cancellable` no longer exists. Now our `RoutePresenter` uses the `OnBackPressedDispatcher` from the Activity to handle callbacks. Documentation [here](https://developer.android.com/guide/navigation/navigation-custom-back).
* `OnBackPressedCallback` is now abstract instead of an interface.


## Screenshots or Videos

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)