### PR TITLE
implement sync interval every 24 hours

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/uiTests/AutoLockTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/uiTests/AutoLockTest.kt
@@ -10,8 +10,8 @@ import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.action.Setting
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.robots.itemList
-import mozilla.lockbox.support.AutoLockSupport
-import mozilla.lockbox.support.LockingSupport
+import mozilla.lockbox.support.TimingSupport
+import mozilla.lockbox.support.SystemTimingSupport
 import mozilla.lockbox.view.RootActivity
 import org.junit.Before
 import org.junit.Ignore
@@ -20,10 +20,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @Ignore("589-UItests-update (#590)")
-class TestLockingSupport() : LockingSupport {
+class TestSystemTimingSupport() : SystemTimingSupport {
     override var systemTimeElapsed: Long = 0L
 
-    constructor(existing: LockingSupport) : this() {
+    constructor(existing: SystemTimingSupport) : this() {
         systemTimeElapsed = existing.systemTimeElapsed
     }
 
@@ -38,14 +38,14 @@ class TestLockingSupport() : LockingSupport {
 @Ignore("589-UItests-update (#590)")
 open class AutoLockTest {
     private val navigator = Navigator()
-    private val testLockingSupport = TestLockingSupport(AutoLockSupport.shared.lockingSupport)
+    private val testLockingSupport = TestSystemTimingSupport(TimingSupport.shared.systemTimingSupport)
 
     @get:Rule
     val activityRule: ActivityTestRule<RootActivity> = ActivityTestRule(RootActivity::class.java)
 
     @Before
     fun setUp() {
-        AutoLockSupport.shared.lockingSupport = testLockingSupport
+        TimingSupport.shared.systemTimingSupport = testLockingSupport
     }
 
     @Test

--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -31,7 +31,7 @@ import mozilla.lockbox.store.SentryStore
 import mozilla.lockbox.store.SettingStore
 import mozilla.lockbox.store.TelemetryStore
 import mozilla.lockbox.support.AdjustSupport
-import mozilla.lockbox.support.AutoLockSupport
+import mozilla.lockbox.support.TimingSupport
 import mozilla.lockbox.support.Constant
 import mozilla.lockbox.support.FxASyncDataStoreSupport
 import mozilla.lockbox.support.PublicSuffixSupport
@@ -85,7 +85,7 @@ open class LockboxApplication : Application() {
         val orderedStores = listOf(
             DataStore.shared,
             AccountStore.shared,
-            AutoLockSupport.shared,
+            TimingSupport.shared,
             LockedStore.shared
         )
         orderedStores.forEach {
@@ -101,7 +101,7 @@ open class LockboxApplication : Application() {
             FxASyncDataStoreSupport.shared,
             ClipboardStore.shared,
             NetworkStore.shared,
-            AutoLockSupport.shared,
+            TimingSupport.shared,
             AccountStore.shared,
             TelemetryStore.shared,
             SentryStore.shared,

--- a/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
@@ -19,12 +19,12 @@ import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.support.ClipboardSupport
 import mozilla.lockbox.support.Constant
-import mozilla.lockbox.support.LockingSupport
-import mozilla.lockbox.support.SystemLockingSupport
+import mozilla.lockbox.support.SystemTimingSupport
+import mozilla.lockbox.support.SystemSystemTimingSupport
 
 open class ClipboardStore(
     val dispatcher: Dispatcher = Dispatcher.shared,
-    private val timerSupport: LockingSupport = SystemLockingSupport()
+    private val timerSupport: SystemTimingSupport = SystemSystemTimingSupport()
 ) : ContextStore {
     internal val compositeDisposable = CompositeDisposable()
 

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -12,6 +12,7 @@ object Constant {
     object Common {
         const val emptyString = ""
         const val sixtySeconds: Long = 60000
+        const val twentyFourHours: Long = 60 * 60 * 24 * 1000
     }
 
     object App {
@@ -65,6 +66,7 @@ object Constant {
         const val firefoxAccount = "firefox-account"
         const val encryptionKey = "database-encryption-key"
         const val autoLockTimerDate = "auto-lock-timer-date"
+        const val syncTimerDate = "sync-timer-date"
         const val bootCompletedIntent = "android.intent.action.BOOT_COMPLETED"
         const val clearClipboardIntent = "mozilla.lockbox.intent.CLEAR_CLIPBOARD"
         const val clipboardDirtyExtra = "clipboard-dirty"

--- a/app/src/main/java/mozilla/lockbox/support/SystemTimingSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/SystemTimingSupport.kt
@@ -2,11 +2,11 @@ package mozilla.lockbox.support
 
 import android.os.SystemClock
 
-interface LockingSupport {
+interface SystemTimingSupport {
     val systemTimeElapsed: Long
 }
 
-class SystemLockingSupport : LockingSupport {
+class SystemSystemTimingSupport : SystemTimingSupport {
     override val systemTimeElapsed: Long
         get() = SystemClock.elapsedRealtime()
 }

--- a/app/src/main/java/mozilla/lockbox/support/TimingSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/TimingSupport.kt
@@ -17,24 +17,37 @@ import mozilla.lockbox.store.ContextStore
 import mozilla.lockbox.store.SettingStore
 
 @ExperimentalCoroutinesApi
-open class AutoLockSupport(
+open class TimingSupport(
     val settingStore: SettingStore = SettingStore.shared
 ) : ContextStore {
 
     companion object {
-        val shared by lazy { AutoLockSupport() }
+        val shared by lazy { TimingSupport() }
     }
 
     private val compositeDisposable = CompositeDisposable()
     private lateinit var preferences: SharedPreferences
 
-    var lockingSupport: LockingSupport = SystemLockingSupport()
+    var systemTimingSupport: SystemTimingSupport = SystemSystemTimingSupport()
 
     open val shouldLock: Boolean
         get() = lockCurrentlyRequired()
 
+    open val shouldSync: Boolean
+        get() = syncCurrentlyRequired()
+
     override fun injectContext(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
+    }
+
+    private fun syncCurrentlyRequired(): Boolean {
+        val syncTimerDate = preferences.getLong(Constant.Key.syncTimerDate, Long.MAX_VALUE)
+        val currentSystemTime = systemTimingSupport.systemTimeElapsed
+
+        // this will be triggered when the system time is very low due to device restarts
+        val currentTimeTooEarly = (syncTimerDate - currentSystemTime) > Constant.Common.twentyFourHours
+
+        return syncTimerDate < currentSystemTime || currentTimeTooEarly
     }
 
     open fun storeNextAutoLockTime() {
@@ -42,6 +55,10 @@ open class AutoLockSupport(
             .take(1)
             .subscribe(this::updateNextLockTime)
             .addTo(compositeDisposable)
+    }
+
+    open fun storeNextSyncTime() {
+        storeSyncTimerDate(systemTimingSupport.systemTimeElapsed + Constant.Common.twentyFourHours)
     }
 
     open fun backdateNextLockTime() {
@@ -56,12 +73,12 @@ open class AutoLockSupport(
         if (autoLockTime == Setting.AutoLockTime.Never) {
             storeAutoLockTimerDate(Long.MAX_VALUE)
         } else {
-            storeAutoLockTimerDate(lockingSupport.systemTimeElapsed + autoLockTime.ms)
+            storeAutoLockTimerDate(systemTimingSupport.systemTimeElapsed + autoLockTime.ms)
         }
     }
 
     private fun lockCurrentlyRequired(): Boolean {
-        val currentSystemTime = lockingSupport.systemTimeElapsed
+        val currentSystemTime = systemTimingSupport.systemTimeElapsed
         return if (currentSystemTime <= Constant.Common.sixtySeconds) {
             true
         } else {
@@ -71,9 +88,16 @@ open class AutoLockSupport(
 
     private fun autoLockTimeElapsed(): Boolean {
         val autoLockTimerDate = preferences.getLong(Constant.Key.autoLockTimerDate, Long.MAX_VALUE)
-        val currentSystemTime = lockingSupport.systemTimeElapsed
+        val currentSystemTime = systemTimingSupport.systemTimeElapsed
 
         return autoLockTimerDate <= currentSystemTime
+    }
+
+    private fun storeSyncTimerDate(dateTime: Long) {
+        preferences
+            .edit()
+            .putLong(Constant.Key.syncTimerDate, dateTime)
+            .apply()
     }
 
     private fun storeAutoLockTimerDate(dateTime: Long) {

--- a/app/src/main/java/mozilla/lockbox/support/TimingSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/TimingSupport.kt
@@ -45,9 +45,9 @@ open class TimingSupport(
         val currentSystemTime = systemTimingSupport.systemTimeElapsed
 
         // this will be triggered when the system time is very low due to device restarts
-        val currentTimeTooEarly = (syncTimerDate - currentSystemTime) > Constant.Common.twentyFourHours
+        val followingDeviceReboot = (syncTimerDate - currentSystemTime) > Constant.Common.twentyFourHours
 
-        return syncTimerDate < currentSystemTime || currentTimeTooEarly
+        return syncTimerDate < currentSystemTime || followingDeviceReboot
     }
 
     open fun storeNextAutoLockTime() {

--- a/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
@@ -14,7 +14,7 @@ import androidx.test.core.app.ApplicationProvider
 import mozilla.lockbox.DisposingTest
 import mozilla.lockbox.action.ClipboardAction
 import mozilla.lockbox.flux.Dispatcher
-import mozilla.lockbox.support.LockingSupport
+import mozilla.lockbox.support.SystemTimingSupport
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Ignore
@@ -30,7 +30,7 @@ import org.robolectric.annotation.Config
 import org.mockito.Mockito.`when` as whenCalled
 
 @Ignore("More reliably clear the clipboard (#644)")
-class TestSystemTimeSupport : LockingSupport {
+class TestSystemTimeSupport : SystemTimingSupport {
     override val systemTimeElapsed: Long = 2000L
 }
 

--- a/app/src/test/java/mozilla/lockbox/support/TimingSupportTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/TimingSupportTest.kt
@@ -12,12 +12,8 @@ import android.os.SystemClock
 import android.preference.PreferenceManager
 import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.Relay
-import io.reactivex.observers.TestObserver
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.Setting
-import mozilla.lockbox.flux.Dispatcher
-import mozilla.lockbox.model.FixedSyncCredentials
 import mozilla.lockbox.store.SettingStore
 import org.junit.Assert
 import org.junit.Before
@@ -39,14 +35,14 @@ import org.powermock.modules.junit4.PowerMockRunner
 import java.lang.Math.abs
 import org.mockito.Mockito.`when` as whenCalled
 
-class TestLockingSupport : LockingSupport {
+class TestSystemTimingSupport : SystemTimingSupport {
     override var systemTimeElapsed: Long = 0L
 }
 
 @ExperimentalCoroutinesApi
 @RunWith(PowerMockRunner::class)
 @PrepareForTest(PreferenceManager::class, SimpleFileReader::class)
-class AutoLockSupportTest {
+class TimingSupportTest {
     @Mock
     val editor: SharedPreferences.Editor = Mockito.mock(SharedPreferences.Editor::class.java)
 
@@ -64,15 +60,11 @@ class AutoLockSupportTest {
 
     var autoLockTimeStub = BehaviorRelay.createDefault(Constant.SettingDefault.autoLockTime)
 
-    private val dispatcher = Dispatcher()
-
     private var bootID = ";kl;jjkloi;kljhafshjkadfsmn"
 
-    private val lockRequiredObserver: TestObserver<Boolean> = TestObserver.create()
+    private val lockingSupport = spy(TestSystemTimingSupport())
 
-    private val lockingSupport = spy(TestLockingSupport())
-
-    lateinit var subject: AutoLockSupport
+    lateinit var subject: TimingSupport
 
     @Before
     fun setUp() {
@@ -89,9 +81,9 @@ class AutoLockSupportTest {
         whenCalled(settingStore.autoLockTime).thenReturn(autoLockTimeStub)
         PowerMockito.whenNew(SettingStore::class.java).withAnyArguments().thenReturn(settingStore)
 
-        subject = AutoLockSupport(settingStore)
+        subject = TimingSupport(settingStore)
         subject.injectContext(context)
-        subject.lockingSupport = lockingSupport
+        subject.systemTimingSupport = lockingSupport
     }
 
     @Test
@@ -116,8 +108,24 @@ class AutoLockSupportTest {
         verify(editor).putLong(
             eq(Constant.Key.autoLockTimerDate),
             longThat { longArg ->
-                abs(SystemClock.elapsedRealtime() + defaultAutoLock.ms - longArg) < 100
+                abs(defaultAutoLock.ms - longArg) < 100
             }
+        )
+
+        verify(editor).apply()
+    }
+
+    @Test
+    fun `storenextsynctime sets the sync time with the default`() {
+        clearInvocations(preferences)
+        clearInvocations(editor)
+        subject.storeNextSyncTime()
+
+        verify(preferences).edit()
+
+        verify(editor).putLong(
+            eq(Constant.Key.syncTimerDate),
+            eq(Constant.Common.twentyFourHours)
         )
 
         verify(editor).apply()
@@ -162,24 +170,11 @@ class AutoLockSupportTest {
 
     @Test
     fun `when the saved autolocktimerdate is later than the current system time`() {
-        dispatcher.dispatch(DataStoreAction.UpdateCredentials(FixedSyncCredentials(false)))
-
         val currSystemTime: Long = Constant.Common.sixtySeconds + 10000
         mockSavedAutoLockTime(lockingSupport.systemTimeElapsed + 120000)
         Mockito.`when`(lockingSupport.systemTimeElapsed).thenReturn(currSystemTime)
 
         Assert.assertFalse(subject.shouldLock)
-    }
-
-    @Test
-    fun `foregrounding lifecycle actions when the saved autolocktimerdate is earlier than the current system time`() {
-        dispatcher.dispatch(DataStoreAction.UpdateCredentials(FixedSyncCredentials(false)))
-
-        val currSystemTime: Long = lockingSupport.systemTimeElapsed - Constant.Common.sixtySeconds
-        mockSavedAutoLockTime(lockingSupport.systemTimeElapsed - currSystemTime)
-        Mockito.`when`(lockingSupport.systemTimeElapsed).thenReturn(currSystemTime)
-
-        Assert.assertTrue(subject.shouldLock)
     }
 
     @Test
@@ -200,8 +195,44 @@ class AutoLockSupportTest {
         verify(editor).apply()
     }
 
+    @Test
+    fun `when the saved synctimerdate is later than the current system time`() {
+        val currSystemTime: Long = Constant.Common.twentyFourHours + 10000
+        mockSavedSyncTime(lockingSupport.systemTimeElapsed + Constant.Common.twentyFourHours + 10000)
+        Mockito.`when`(lockingSupport.systemTimeElapsed).thenReturn(currSystemTime)
+
+        Assert.assertFalse(subject.shouldSync)
+    }
+
+    @Test
+    fun `when the saved synctimerdate is earlier than the current system time`() {
+        val currSystemTime: Long = Constant.Common.twentyFourHours + 10000
+        mockSavedSyncTime(10000)
+        Mockito.`when`(lockingSupport.systemTimeElapsed).thenReturn(currSystemTime)
+
+        Assert.assertTrue(subject.shouldSync)
+    }
+
+    @Test
+    fun `when the saved synctimerdate is later than the current system time by more than the sync interval`() {
+        val currSystemTime: Long = 100
+        mockSavedSyncTime(Constant.Common.twentyFourHours + 500000)
+        Mockito.`when`(lockingSupport.systemTimeElapsed).thenReturn(currSystemTime)
+
+        Assert.assertTrue(subject.shouldSync)
+    }
+
     private fun mockSavedAutoLockTime(autoLockTimerDate: Long) {
-        whenCalled(preferences.getLong(anyString(), anyLong())).thenReturn(autoLockTimerDate)
+        whenCalled(preferences.getLong(eq(Constant.Key.autoLockTimerDate), anyLong())).thenReturn(autoLockTimerDate)
+
+        PowerMockito.mockStatic(PreferenceManager::class.java)
+        whenCalled(PreferenceManager.getDefaultSharedPreferences(context)).thenReturn(preferences)
+
+        subject.injectContext(context)
+    }
+
+    private fun mockSavedSyncTime(syncTimerDate: Long) {
+        whenCalled(preferences.getLong(eq(Constant.Key.syncTimerDate), anyLong())).thenReturn(syncTimerDate)
 
         PowerMockito.mockStatic(PreferenceManager::class.java)
         whenCalled(PreferenceManager.getDefaultSharedPreferences(context)).thenReturn(preferences)


### PR DESCRIPTION
Fixes #735 
Connected to #754

## Testing and Review Notes

Currently, manual sync resets the 24 hour timer, so if you would like to see an automatic sync, don't sync manually!

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
