### PR TITLE
Fixes #723 - Bottom text is cut from the screen

### DIFF
--- a/app/src/main/res/layout/fragment_autofill_onboarding.xml
+++ b/app/src/main/res/layout/fragment_autofill_onboarding.xml
@@ -110,7 +110,7 @@
     <Button
             android:id="@+id/skipButton"
             android:layout_width="wrap_content"
-            android:layout_height="36dp"
+            android:layout_height="wrap_content"
             android:gravity="center_horizontal|center_vertical"
             android:text="@string/onboarding_skip"
             android:textAllCaps="true"

--- a/app/src/main/res/layout/fragment_fingerprint_onboarding.xml
+++ b/app/src/main/res/layout/fragment_fingerprint_onboarding.xml
@@ -142,7 +142,7 @@
     <Button
             android:id="@+id/skipButton"
             android:layout_width="wrap_content"
-            android:layout_height="36dp"
+            android:layout_height="wrap_content"
             android:gravity="center_horizontal|center_vertical"
             android:text="@string/onboarding_skip"
             android:textAllCaps="true"


### PR DESCRIPTION
Fixes #723

Setting the layout_height in dp(36dp) cuts part of the text on some screens (S8+), the best approach is to use "wrap_content".
