### PR TITLE
758-uitests-fix-fxaLogin

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/uiTests/AppRoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/uiTests/AppRoutePresenterTest.kt
@@ -31,12 +31,6 @@ open class AppRoutePresenterTest {
     @Rule @JvmField
     val activityRule: ActivityTestRule<RootActivity> = ActivityTestRule(RootActivity::class.java)
 
-    @Test
-    fun testFxALogin() {
-        // There is a check that the view is correct
-        navigator.gotoFxALogin()
-    }
-
     @Ignore("619-ui-tests-bitrise (#620)")
     @Test
     fun testFingerprintOnboarding() {
@@ -89,8 +83,6 @@ open class AppRoutePresenterTest {
         navigator.gotoDisconnectDisclaimer()
         navigator.back()
         navigator.checkAtAccountSetting()
-        navigator.back()
-        navigator.back()
     }
 
     @Ignore("619-ui-tests-bitrise (#620)")

--- a/app/src/androidTest/java/mozilla/lockbox/uiTests/OnboardingTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/uiTests/OnboardingTest.kt
@@ -37,6 +37,12 @@ open class OnboardingTest {
     }
 
     @Test
+    fun testFxALogin() {
+        // There is a check that the view is correct
+        navigator.gotoFxALogin()
+    }
+
+    @Test
     fun testOnboardingConfirmation() {
         navigator.gotoOnboardingConfirmation()
         onboardingConfirmationScreen { clickFinish() }


### PR DESCRIPTION
Fixes #785 
Test FxALogin is failing when running it on Firebase sims. It start so fast that there is no way to check for the `getStarted`button. Chaging it to a different test suite, also where it makes more sense helps to have it working and allows to remove some "workaround" lines we had in the past so that it worked 