### PR TITLE
805: Ellipsize text in item list

### DIFF
--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -93,51 +93,67 @@
                 android:paddingBottom="26dp"
                 tools:ignore="RtlSymmetry">
 
-            <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/inputLayoutHostname"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                    android:orientation="horizontal"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingStart="16dp"
-                    android:textColorHint="@color/black_60_percent"
-                    android:contentDescription="@string/launch_hostname_content_description"
-                    app:layout_constraintTop_toTopOf="parent"
+                    card_view:layout_constraintTop_toTopOf="parent"
                     card_view:layout_constraintStart_toStartOf="parent"
                     card_view:layout_constraintEnd_toEndOf="parent"
-                    tools:ignore="RtlSymmetry">
-
-                <EditText
-                        android:id="@+id/inputHostname"
-                        style="@style/EditTextStyle"
+                    android:id="@+id/hostname" >
+                <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/inputLayoutHostname"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:hint="@string/hint_hostname"
-                        android:inputType="textNoSuggestions"
-                        android:singleLine="true"
-                        android:textColor="@color/violet_70"
-                        android:clickable="true"
-                        android:focusable="true"
-                        tools:ignore="Autofill"/>
+                        android:scrollbars="none"
+                        android:paddingStart="16dp"
+                        android:layout_marginEnd="30dp"
+                        android:textColorHint="@color/black_60_percent"
+                        android:contentDescription="@string/launch_hostname_content_description"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        tools:ignore="RtlSymmetry">
 
-            </com.google.android.material.textfield.TextInputLayout>
+                    <EditText
+                            android:id="@+id/inputHostname"
+                            style="@style/EditTextStyle"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/hint_hostname"
+                            android:scrollHorizontally="true"
+                            android:lines="1"
+                            android:ellipsize="end"
+                            android:inputType="textNoSuggestions"
+                            android:maxLines="1"
+                            android:textColor="@color/violet_70"
+                            android:clickable="true"
+                            android:focusable="true"
+                            tools:ignore="Autofill"/>
 
-            <ImageView
-                    android:id="@+id/btnHostnameLaunch"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:padding="8dp"
-                    android:background="@null"
-                    tools:ignore="ContentDescription"
-                    app:layout_constraintBottom_toBottomOf="@+id/inputLayoutHostname"
-                    app:layout_constraintRight_toRightOf="@+id/inputLayoutHostname"
-                    app:layout_constraintTop_toTopOf="@+id/inputLayoutHostname"
-                    app:srcCompat="@drawable/ic_launch"/>
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <ImageView
+                        android:id="@+id/btnHostnameLaunch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:padding="8dp"
+                        android:paddingStart="16dp"
+                        android:background="@null"
+                        tools:ignore="ContentDescription"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toEndOf="@id/inputLayoutHostname"
+                        app:srcCompat="@drawable/ic_launch"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <View
                     android:layout_height="1dp"
                     android:layout_width="match_parent"
                     android:background="@color/gray_divider"
                     android:layout_marginStart="16dp"
-                    card_view:layout_constraintTop_toBottomOf="@id/inputLayoutHostname"
+                    card_view:layout_constraintTop_toBottomOf="@id/hostname"
             />
 
             <com.google.android.material.textfield.TextInputLayout
@@ -148,7 +164,7 @@
                     android:layout_marginTop="16dp"
                     android:paddingStart="16dp"
                     android:textColorHint="@color/black_60_percent"
-                    app:layout_constraintTop_toBottomOf="@id/inputLayoutHostname"
+                    app:layout_constraintTop_toBottomOf="@id/hostname"
                     card_view:layout_constraintStart_toStartOf="parent"
                     card_view:layout_constraintEnd_toEndOf="parent"
                     tools:ignore="RtlSymmetry">

--- a/app/src/main/res/layout/list_cell_item.xml
+++ b/app/src/main/res/layout/list_cell_item.xml
@@ -14,14 +14,17 @@
 
     <TextView
         android:id="@+id/itemTitle"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textSize="16sp"
+        android:layout_marginEnd="16dp"
         android:fontFamily="sans-serif"
         android:textStyle="normal"
         android:textColor="@color/text_ink"
+        android:ellipsize="end"
         android:letterSpacing="0.01"
         android:lineSpacingExtra="8sp"
+        android:maxLines="1"
         android:layout_marginStart="16dp"
         android:layout_marginTop="10dp"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION

Fixes #805

## Testing and Review Notes
Sets the max number of lines for the hostname to 1 (with an ellipse at the end if it's longer) on the item list.

## Screenshots or Videos
<img width="464" alt="Screen Shot 2019-07-03 at 2 32 53 PM" src="https://user-images.githubusercontent.com/43795363/60626428-9237c480-9d9f-11e9-94c0-8d705b8060b3.png">

In the item details we can't make the hostname ellipsized because the view type, `EditText`, is always horizontally scrollable:
<img width="350" alt="Screen Shot 2019-07-03 at 2 32 53 PM" src="https://user-images.githubusercontent.com/43795363/60626402-80eeb800-9d9f-11e9-8d2b-13bcc515cff8.png">


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
