### PR TITLE
773: Adjust spinner dropdown size to fit longer words (l10n)

### DIFF
--- a/app/src/main/res/layout/fragment_item_list.xml
+++ b/app/src/main/res/layout/fragment_item_list.xml
@@ -45,7 +45,7 @@
                             android:contentDescription="@string/sort_description"
                             android:overlapAnchor="false"
                             android:popupElevation="8dp"
-                            android:dropDownWidth="150dp"
+                            android:dropDownWidth="170dp"
                             android:dropDownSelector="@color/selection"
                             android:spinnerMode="dropdown"
                             android:popupBackground="@drawable/sort_menu_bg"


### PR DESCRIPTION
Fixes #773

## Testing and Review Notes


## Screenshots or Videos
English: 
<img width="418" alt="image" src="https://user-images.githubusercontent.com/43795363/60627353-a6c98c00-9da2-11e9-99d5-c45ec9065842.png">


Spanish: 
<img width="418" alt="image" src="https://user-images.githubusercontent.com/43795363/60627338-9a453380-9da2-11e9-85c9-ab642a58684e.png">


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)


