### PR TITLE
810: Reset support when syncing

### DIFF
--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -236,21 +236,12 @@ open class DataStore(
     }
 
     private fun sync() {
-        val syncConfig = if (support.syncConfig != null) {
-            support.syncConfig
-        } else {
-            log.error("Support sync config is null: $support")
-            val throwable = IllegalStateException("syncConfig should already be defined in $support")
-            pushError(throwable)
-
-            resetSupport(support)
-            support.syncConfig
-        }
+        resetSupport(support)
 
         // ideally, we don't sync unless we are connected to the network
         syncStateSubject.accept(SyncState.Syncing)
 
-        backend.sync(syncConfig!!)
+        backend.sync(support.syncConfig!!)
             .asSingle(coroutineContext)
             .timeout(Constant.App.syncTimeout, TimeUnit.SECONDS)
             .doOnEvent { _, err ->


### PR DESCRIPTION
Fixes #810

## Testing and Review Notes
Instead of just throwing an exception when the `support.syncConfig` is null, reset the `support` every time we sync to get the new access tokens, etc. This is the expected behavior as seen in A-C examples.

## Screenshots or Videos


## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
