### PR TITLE
Removing timeout to be fixed in #791

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -71,7 +71,7 @@ class ItemListPresenter(
             .map {
                 when (it) {
                     DataStore.SyncState.Syncing -> true
-                    DataStore.SyncState.NotSyncing, DataStore.SyncState.TimedOut -> false
+                    DataStore.SyncState.NotSyncing -> false
                 }
             }
             .subscribe { syncing ->
@@ -84,13 +84,14 @@ class ItemListPresenter(
             }
             .addTo(compositeDisposable)
 
-        dataStore.syncState
-            .filter { it == DataStore.SyncState.TimedOut }
-            .map { R.string.sync_timed_out }
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(view::showToastNotification)
-            .addTo(compositeDisposable)
-
+        /* timeout to be fixed in https://github.com/mozilla-lockwise/lockwise-android/issues/791
+              dataStore.syncState
+                  .filter { it == DataStore.SyncState.TimedOut }
+                  .map { R.string.sync_timed_out }
+                  .observeOn(AndroidSchedulers.mainThread())
+                  .subscribe(view::showToastNotification)
+                  .addTo(compositeDisposable)
+        */
         Observables.combineLatest(dataStore.list, settingStore.itemListSortOrder)
             .distinctUntilChanged()
             .map { pair ->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -252,5 +252,5 @@
 
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(Kein Benutzername)</string>
-    <string name="sync_timed_out">Zeitüberschreitung bei Synchronisation</string>
+    <!--<string name="sync_timed_out">Zeitüberschreitung bei Synchronisation</string>-->
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -252,5 +252,5 @@
 
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(no existe usuario)</string>
-    <string name="sync_timed_out">La sincronización ha expirado</string>
+    <!--<string name="sync_timed_out">La sincronización ha expirado</string>-->
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -250,5 +250,5 @@
 
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(aucun nom d’utilisateur)</string>
-    <string name="sync_timed_out">Délai de synchronisation dépassé</string>
+    <!--<string name="sync_timed_out">Délai de synchronisation dépassé</string>-->
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -258,5 +258,5 @@
 
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">[nessun nome utente]</string>
-    <string name="sync_timed_out">Tempo per la sincronizzazione scaduto</string>
+    <!--<string name="sync_timed_out">Tempo per la sincronizzazione scaduto</string>-->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,7 +258,7 @@
     <string name="no_username">(no username)</string>
 
     <!-- This is the message displayed when sync has timed out. -->
-    <string name="sync_timed_out">Syncing has timed out</string>
+    <!--<string name="sync_timed_out">Syncing has timed out</string>-->
 
     <!-- This is the description for the kebab menu in the item detail toolbar. -->
     <string name="kebab_menu">More options</string>

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemListPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemListPresenterTest.kt
@@ -327,14 +327,14 @@ open class ItemListPresenterTest {
         syncStateStub.onNext(DataStore.SyncState.NotSyncing)
         Assert.assertEquals(false, view.isLoading)
     }
-
+    /* timeout to be fixed in https://github.com/mozilla-lockwise/lockwise-android/issues/791
     @Test
     fun `sync timeout indicator`() {
         syncStateStub.onNext(DataStore.SyncState.TimedOut)
         Assert.assertEquals(false, view.isLoading)
         Assert.assertEquals(R.string.sync_timed_out, view.toastNotificationArgStrId)
     }
-
+    */
     @Test
     fun `item deleted toast`() {
         val item = ServerPasswordTestHelper().item1

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -212,7 +212,7 @@ class DataStoreTest : DisposingTest() {
         Assert.assertEquals(expectedSyncUnlockInfo.syncKey, support.syncConfig!!.syncKey)
         Assert.assertEquals(expectedSyncUnlockInfo.tokenserverURL, support.syncConfig!!.tokenserverURL)
     }
-
+    /* timeout to be fixed in https://github.com/mozilla-lockwise/lockwise-android/issues/791
     @Test
     fun testSync() {
         val syncIterator = this.subject.syncState.blockingIterable().iterator()
@@ -222,7 +222,7 @@ class DataStoreTest : DisposingTest() {
         Assert.assertEquals(DataStore.SyncState.Syncing, syncIterator.next())
         Assert.assertEquals(DataStore.SyncState.TimedOut, syncIterator.next())
     }
-
+    */
     @Test
     fun testGet() {
         val stateIterator = this.subject.state.blockingIterable().iterator()


### PR DESCRIPTION
Fixes N/A

## Testing and Review Notes
Per discussion with @yuvalwolf, removing the toast notification for sync timeout until we can provide a fix in #791.

## Screenshots or Videos


## To Do

- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
