### PR TITLE
WIP Automatic FxA sign-in support

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/AccountAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/AccountAction.kt
@@ -6,10 +6,12 @@
 
 package mozilla.lockbox.action
 
+import mozilla.components.service.fxa.sharing.ShareableAccount
 import mozilla.lockbox.flux.Action
 
 sealed class AccountAction : Action {
     object Reset : AccountAction()
     object UseTestData : AccountAction()
     data class OauthRedirect(val url: String) : AccountAction()
+    data class AutomaticLogin(val account: ShareableAccount) : AccountAction()
 }

--- a/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
@@ -6,6 +6,7 @@
 
 package mozilla.lockbox.action
 
+import mozilla.components.service.fxa.sharing.ShareableAccount
 import mozilla.lockbox.R
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.model.DialogViewModel
@@ -34,7 +35,20 @@ sealed class DialogAction(
         ),
         listOf(LifecycleAction.UserReset)
     )
-    object OnboardingSecurityDialog : DialogAction(
+    data class OnboardingSecurityDialogAutomatic(val account: ShareableAccount) : DialogAction(
+        DialogViewModel(
+            R.string.secure_your_device,
+            R.string.device_security_description,
+            R.string.set_up_now,
+            R.string.skip_button
+        ),
+        listOf(
+            RouteAction.SystemSetting(SettingIntent.Security),
+            AccountAction.AutomaticLogin(account)
+        ),
+        listOf(RouteAction.Login)
+    )
+    object OnboardingSecurityDialogManual : DialogAction(
             DialogViewModel(
                 R.string.secure_your_device,
                 R.string.device_security_description,

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -28,6 +28,8 @@ import mozilla.components.concept.sync.AccessTokenInfo
 import mozilla.components.concept.sync.Avatar
 import mozilla.components.concept.sync.Profile
 import mozilla.components.service.fxa.FirefoxAccount
+import mozilla.components.service.fxa.sharing.AccountSharing
+import mozilla.components.service.fxa.sharing.ShareableAccount
 import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
@@ -91,6 +93,7 @@ open class AccountStore(
 
     private lateinit var webView: WebView
     private lateinit var logDirectory: File
+    private lateinit var context: Context
 
     init {
         val resetObservable = lifecycleStore.lifecycleEvents
@@ -109,6 +112,7 @@ open class AccountStore(
                 when (it) {
                     is AccountAction.OauthRedirect -> this.oauthLogin(it.url)
                     is AccountAction.UseTestData -> this.populateTestAccountInformation(true)
+                    is AccountAction.AutomaticLogin -> this.automaticLogin(it.account)
                     is AccountAction.Reset -> this.clear()
                 }
             }
@@ -126,8 +130,23 @@ open class AccountStore(
 
     override fun injectContext(context: Context) {
         detectAccount()
+        this.context = context
         webView = WebView(context)
         logDirectory = context.getDir("webview", Context.MODE_PRIVATE)
+    }
+
+    fun shareableAccount(): ShareableAccount? {
+        return AccountSharing.queryShareableAccounts(context).firstOrNull()
+    }
+
+    private fun automaticLogin(account: ShareableAccount) {
+        fxa?.migrateFromSessionTokenAsync(
+            account.authInfo.sessionToken,
+            account.authInfo.kSync,
+            account.authInfo.kXCS
+        )?.asSingle(coroutineContext)
+            ?.subscribe(this::populateAccountInformation, this::pushError)
+            ?.addTo(compositeDisposable)
     }
 
     private fun detectAccount() {

--- a/app/src/main/java/mozilla/lockbox/view/WelcomeFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/WelcomeFragment.kt
@@ -10,14 +10,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.transition.Visibility
 import io.reactivex.Observable
 import com.jakewharton.rxbinding2.view.clicks
 import kotlinx.android.synthetic.main.fragment_welcome.view.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
 import mozilla.lockbox.presenter.WelcomePresenter
 import mozilla.lockbox.presenter.WelcomeView
+import mozilla.lockbox.store.AccountStore
 
 class WelcomeFragment : Fragment(), WelcomeView {
+    @ExperimentalCoroutinesApi
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -28,11 +32,22 @@ class WelcomeFragment : Fragment(), WelcomeView {
         val appLabel = getString(R.string.app_label)
         view.textViewInstructions.text = getString(R.string.welcome_instructions, appLabel)
         view.lockwiseIcon.contentDescription = getString(R.string.app_logo, appLabel)
+
+        val existingAccount = AccountStore.shared.shareableAccount()
+        if (existingAccount != null) {
+            view.buttonGetStarted.text = getString(R.string.welcome_start_automatic_btn, existingAccount.email)
+            view.buttonGetStartedManually.text = getString(R.string.welcome_start_force_manual_btn)
+        } else {
+            view.buttonGetStartedManually.visibility = View.GONE
+        }
         return view
     }
 
-    override val getStartedClicks: Observable<Unit>
+    override val getStartedAutomaticallyClicks: Observable<Unit>
         get() = view!!.buttonGetStarted.clicks()
+
+    override val getStartedManuallyClicks: Observable<Unit>
+        get() = view!!.buttonGetStartedManually.clicks()
 
     override val learnMoreClicks: Observable<Unit>
         get() = view!!.textViewLearnMore.clicks()

--- a/app/src/main/res/layout/fragment_welcome.xml
+++ b/app/src/main/res/layout/fragment_welcome.xml
@@ -73,6 +73,20 @@
 
         <Button
             android:id="@+id/buttonGetStarted"
+            android:layout_width="220dp"
+            android:layout_height="36dp"
+            android:layout_marginBottom="8dp"
+            android:background="@drawable/button_pressed_violet"
+            android:letterSpacing="0.09"
+            android:lineSpacingExtra="2sp"
+            android:text="@string/welcome_start_btn"
+            android:textColor="@color/text_white"
+            android:textStyle="normal"
+            android:layout_gravity="center"
+        />
+
+        <Button
+            android:id="@+id/buttonGetStartedManually"
             android:layout_width="180dp"
             android:layout_height="36dp"
             android:layout_marginBottom="8dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,7 +17,11 @@
     <!-- This is the label a screenreader uses to inform the user they selected a link that will open a webpage to learn more about the feature or setting. -->
     <string name="learn_more_description">Open a link to Learn more</string>
 
-    <!-- This is used as the label on a button on a first-run welcome screen to sign in and start using the application -->
+    <!-- This is used as the label on a button on a first-run welcome screen to automatically sign in to an existing account and start using the application -->
+    <string name="welcome_start_automatic_btn">%s</string>
+    <!-- This is used as the label on a button on a first-run welcome screen to force manual sign in and start using the application -->
+    <string name="welcome_start_force_manual_btn">Different Account</string>
+    <!-- This is used as the label on a button on a first-run welcome screen to manually sign in (no existing account) and start using the application -->
     <string name="welcome_start_btn">Get Started</string>
     <!-- This provides context near a button on the first-run welcome screen to describe application requirements. Firefox Account is to be translated consistently to match use in other Firefox products. %1$s will be replaced with application name. -->
     <string name="welcome_instructions">To use %1$s, you’ll need a Firefox Account with saved logins.</string>

--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,11 @@
 buildscript {
     ext.android_support_version = '28.0.0'
     ext.kotlin_version = '1.3.0'
-    ext.android_components_version = '4.0.0'
+    ext.android_components_version = '6.0.0-SNAPSHOT'
     // Determined from
     // https://github.com/mozilla-mobile/android-components/blob/v0.51.0/buildSrc/src/main/java/Dependencies.kt,
     // where the version in the URL is the tag corresponding to `android_components_version`.
-    ext.mozilla_appservices_version = '0.32.0'
+    ext.mozilla_appservices_version = '0.34.0'
     ext.lifecycle_version = '1.1.1'
     ext.navigation_version = '1.0.0'
     ext.rxbinding_version = '2.2.0'


### PR DESCRIPTION
This is a functional demo (needs UI/UX polish) of FxA auto-sign functionality which we just landed in https://github.com/mozilla-mobile/android-components/pull/3905

This allows Lockwise to automatically sign-in into an account that's present on Firefox for Android. Lockwise is already whitelisted for FxA auth access on released Firefox for Android.

Sometime soon, Fenix will be able to act as an authentication state provider as well. 

~Before landing this make sure this landed: https://github.com/mozilla-mobile/android-components/pull/3806 (we need API fixes in a-s 0.35.4)~