### PR TITLE
Update app services, android components, and megazord configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,6 +106,7 @@ dependencies {
     implementation "org.mozilla.components:lib-dataprotect:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-publicsuffixlist:${rootProject.ext.android_components_version}"
+    implementation "org.mozilla.components:support-rusthttp:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:support-rustlog:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:concept-sync:${rootProject.ext.android_components_version}"
 
@@ -151,6 +152,14 @@ dependencies {
     androidTestImplementation 'br.com.concretesolutions:kappuccino:1.2.1'
     ktlint "com.github.shyiko:ktlint:0.28.0"
     androidTestImplementation "tools.fastlane:screengrab:1.2.0"
+    modules {
+        module('org.mozilla.appservices:full-megazord') {
+            replacedBy('org.mozilla.appservices:lockbox-megazord', 'prefer the lockbox megazord, to reduce final application size')
+        }
+        module('org.mozilla.appservices:lockbox-megazord') {
+            replacedBy('org.mozilla.appservices:lockbox-megazord-forUnitTests', 'prefer the forUnitTests variant if present')
+        }
+    }
 }
 
 sentry {
@@ -254,35 +263,3 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 
 // Internal, but stable and convenient.
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-
-// This is the equivalent of what the `org.mozilla.appservices` Gradle plugin
-// achieved, minus asserting that the versions of all the megazord components
-// agree.  That assertion could be added if required.
-afterEvaluate {
-    // The definitions of the megazords themselves evolve: this set was determined from
-    // https://github.com/mozilla/application-services/blob/v0.27.0/megazords/lockbox/android/build.gradle#L79-L82,
-    // where the version in the URL is the tag corresponding to `mozilla_appservices_version`.  This
-    // will need to be bumped when `android_components_version` (and thus
-    // `mozilla_appservices_version`) is rolled forward.
-    def megazord = DefaultModuleIdentifier.newId('org.mozilla.appservices', 'lockbox-megazord')
-    def megazordComponents = [
-        DefaultModuleIdentifier.newId('org.mozilla.appservices', 'fxaclient'),
-        DefaultModuleIdentifier.newId('org.mozilla.appservices', 'logins'),
-        DefaultModuleIdentifier.newId('org.mozilla.appservices', 'rustlog'),
-    ]
-
-    configurations.each { configuration ->
-        configuration.resolutionStrategy.dependencySubstitution.all { dependency ->
-            if (dependency.requested instanceof ModuleComponentSelector) {
-                def moduleIdentifier = ((ModuleComponentSelector) dependency.requested).moduleIdentifier
-                if (megazordComponents.contains(moduleIdentifier)) {
-                    def megazordVersion = rootProject.ext.mozilla_appservices_version
-                    def substitution = "${megazord.group}:${megazord.name}:${megazordVersion}"
-                    logger.lifecycle("In ${configuration}: substituting megazord module '$substitution' for component module" +
-                                     " '${moduleIdentifier.group}:${moduleIdentifier.name}:${dependency.requested.version}'")
-                    dependency.useTarget(substitution)
-                }
-            }
-        }
-    }
-}

--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -13,7 +13,8 @@ import com.adjust.sdk.Adjust
 import com.adjust.sdk.AdjustConfig
 import com.squareup.leakcanary.LeakCanary
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import mozilla.appservices.LockboxMegazord
+import mozilla.appservices.Megazord
+import mozilla.components.support.rusthttp.RustHttpConfig
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.logger.Logger
@@ -77,7 +78,8 @@ open class LockboxApplication : Application() {
     }
 
     private fun setupDataStoreSupport() {
-        LockboxMegazord.init(lazy { HttpURLConnectionClient() })
+        Megazord.init()
+        RustHttpConfig.setClient(lazy { HttpURLConnectionClient() })
         RustLog.enable()
 
         FxASyncDataStoreSupport.shared.injectContext(this)

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -22,11 +22,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.rx2.asMaybe
 import kotlinx.coroutines.rx2.asSingle
-import mozilla.appservices.fxaclient.Config
 import mozilla.appservices.fxaclient.FxaException
 import mozilla.components.concept.sync.AccessTokenInfo
 import mozilla.components.concept.sync.Avatar
 import mozilla.components.concept.sync.Profile
+import mozilla.components.service.fxa.ServerConfig
 import mozilla.components.service.fxa.FirefoxAccount
 import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.DataStoreAction
@@ -189,7 +189,7 @@ open class AccountStore(
 
     private fun generateNewFirefoxAccount() {
         try {
-            val config = Config.release(Constant.FxA.clientID, Constant.FxA.redirectUri)
+            val config = ServerConfig.release(Constant.FxA.clientID, Constant.FxA.redirectUri)
             fxa = FirefoxAccount(config)
             generateLoginURL()
         } catch (e: FxaException) {

--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -243,6 +243,7 @@ open class DataStore(
 
         backend.sync(support.syncConfig!!)
             .asSingle(coroutineContext)
+            .map { log.debug("### ping: $it") }
             .timeout(Constant.App.syncTimeout, TimeUnit.SECONDS)
             .doOnEvent { _, err ->
                 (err as? TimeoutException).let {

--- a/app/src/test/java/mozilla/lockbox/mocks/MockLoginsStorage.kt
+++ b/app/src/test/java/mozilla/lockbox/mocks/MockLoginsStorage.kt
@@ -9,6 +9,7 @@ package mozilla.lockbox.mocks
 import mozilla.appservices.logins.LoginsStorage
 import mozilla.appservices.logins.ServerPassword
 import mozilla.appservices.logins.SyncUnlockInfo
+import mozilla.appservices.sync15.SyncTelemetryPing
 import mozilla.components.service.sync.logins.AsyncLoginsStorage
 import mozilla.components.service.sync.logins.AsyncLoginsStorageAdapter
 import mozilla.lockbox.support.DataStoreSupport
@@ -60,7 +61,14 @@ open class MockLoginsStorage : LoginsStorage {
 
     override fun close() {}
 
-    override fun sync(syncInfo: SyncUnlockInfo) {}
+    override fun sync(syncInfo: SyncUnlockInfo): SyncTelemetryPing {
+        return SyncTelemetryPing(
+            version = 1,
+            uid = "uid",
+            events = emptyList(),
+            syncs = emptyList()
+        )
+    }
 
     override fun reset() {}
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,12 @@
 buildscript {
     ext.android_support_version = '28.0.0'
     ext.kotlin_version = '1.3.0'
-    ext.android_components_version = '4.0.0'
+    // XXX: might not want to use the prerelease version?
+    ext.android_components_version = '7.0.0-SNAPSHOT'
     // Determined from
     // https://github.com/mozilla-mobile/android-components/blob/v0.51.0/buildSrc/src/main/java/Dependencies.kt,
     // where the version in the URL is the tag corresponding to `android_components_version`.
-    ext.mozilla_appservices_version = '0.32.0'
+    ext.mozilla_appservices_version = '0.36.0'
     ext.lifecycle_version = '1.1.1'
     ext.navigation_version = '1.0.0'
     ext.rxbinding_version = '2.2.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,3 +5,27 @@
  */
 
 include ':app', ':thirdparty'
+
+// Allow substituting the local application-services path, avoiding the need to
+// do a local publish for most cases.
+Properties localProperties = null;
+String settingAppServicesPath = "substitutions.application-services.dir";
+
+if (file('local.properties').canRead()) {
+    localProperties = new Properties()
+    localProperties.load(file('local.properties').newDataInputStream())
+    logger.lifecycle('Local configuration: loaded local.properties')
+} else {
+    logger.lifecycle('Local configuration: absent local.properties; proceeding as normal.')
+}
+
+if (localProperties != null) {
+    String appServicesLocalPath = localProperties.getProperty(settingAppServicesPath);
+
+    if (appServicesLocalPath != null) {
+        logger.lifecycle("Local configuration: substituting application-services modules from path: $appServicesLocalPath")
+        includeBuild(appServicesLocalPath)
+    } else {
+        logger.lifecycle("Local configuration: application-services substitution path missing. Specify it via '$settingAppServicesPath' setting.")
+    }
+}


### PR DESCRIPTION
As discussed in the last A-S/Lockwise meeting, this is a PR that updates A-S/A-C to the new megazord configuration. It also includes the long-awaited telemetry ping support, however it just logs it to the console in a hacky way.

This is a PR, but as discussed, I won't have time to see this through, so someone should take it over for me. At a minimum I think:

- you should figure out what you want to do with the telemetry ping (you probably shouldn't just log it)
- you should wait until A-C 7.0.0 is actually released instead of a snapshot version, unless yoou want to move to using snapshots the way fenix/r-b do.
