### PR TITLE
Import strings from android-l10n

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -252,5 +252,18 @@
 
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(Kein Benutzername)</string>
-    <!--<string name="sync_timed_out">Zeitüberschreitung bei Synchronisation</string>-->
+
+    <!-- This is the message displayed when sync has timed out. -->
+    <!--<string name="sync_timed_out">Syncing has timed out</string>-->
+
+    <!-- This is the description for the kebab menu in the item detail toolbar. -->
+    <string name="kebab_menu">Weitere Optionen</string>
+    <!-- This is the text on an item in the item detail toolbar menu to delete an entry. -->
+    <string name="delete">Löschen</string>
+    <!-- This is the confirmation message title seen when attempting to delete a login. -->
+    <string name="delete_this_login">Diese Zugangsdaten löschen?</string>
+    <!-- This is the description for the deletion dialog. -->
+    <string name="delete_description">Dies löscht diese Zugangsdaten von %1$s und Firefox.</string>
+    <!-- This is the text on an item in the item detail toolbar menu to edit an entry. -->
+    <string name="edit">Bearbeiten</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -252,5 +252,5 @@
 
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(no existe usuario)</string>
-    <!--<string name="sync_timed_out">La sincronización ha expirado</string>-->
+    <string name="sync_timed_out">La sincronización ha expirado</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -250,5 +250,18 @@
 
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(aucun nom d’utilisateur)</string>
-    <!--<string name="sync_timed_out">Délai de synchronisation dépassé</string>-->
+
+    <!-- This is the message displayed when sync has timed out. -->
+    <!--<string name="sync_timed_out">Syncing has timed out</string>-->
+
+    <!-- This is the description for the kebab menu in the item detail toolbar. -->
+    <string name="kebab_menu">Plus d’options</string>
+    <!-- This is the text on an item in the item detail toolbar menu to delete an entry. -->
+    <string name="delete">Supprimer</string>
+    <!-- This is the confirmation message title seen when attempting to delete a login. -->
+    <string name="delete_this_login">Supprimer cet identifiant ?</string>
+    <!-- This is the description for the deletion dialog. -->
+    <string name="delete_description">Cette action supprimera l’identifiant à la fois de %1$s et de Firefox.</string>
+    <!-- This is the text on an item in the item detail toolbar menu to edit an entry. -->
+    <string name="edit">Modifier</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -258,5 +258,18 @@
 
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">[nessun nome utente]</string>
-    <!--<string name="sync_timed_out">Tempo per la sincronizzazione scaduto</string>-->
+
+    <!-- This is the message displayed when sync has timed out. -->
+    <!--<string name="sync_timed_out">Syncing has timed out</string>-->
+
+    <!-- This is the description for the kebab menu in the item detail toolbar. -->
+    <string name="kebab_menu">Altre opzioni</string>
+    <!-- This is the text on an item in the item detail toolbar menu to delete an entry. -->
+    <string name="delete">Elimina</string>
+    <!-- This is the confirmation message title seen when attempting to delete a login. -->
+    <string name="delete_this_login">Eliminare questa credenziale?</string>
+    <!-- This is the description for the deletion dialog. -->
+    <string name="delete_description">Questa operazione eliminerà la credenziale sia da %1$s che da Firefox.</string>
+    <!-- This is the text on an item in the item detail toolbar menu to edit an entry. -->
+    <string name="edit">Modifica</string>
 </resources>

--- a/l10n.toml
+++ b/l10n.toml
@@ -4,7 +4,8 @@ locales = [
   "de",
   "es",
   "fr",
-  "it"
+  "it",
+  "vi",
 ]
 [env]
 


### PR DESCRIPTION
State: mozilla-l10n/android-l10n@413e05dba427ef8cbf9e5272ae5cc3b3ccdf91d3

I wonder what's going to become of `sync_timed_out` in the app repo. I'm hesitent to take action on the l10n side, but given how long this has been commented out, is that string just dead?

CC @Delphine to also see the replies.