### PR TITLE
867 - Fix obvious NPE sync crash

### DIFF
--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -57,6 +57,15 @@ class DataStoreTest : DisposingTest() {
     }
 
     @Test
+    fun `test issue 867 sync crash`() {
+        support.syncConfig = null
+        Assert.assertNull(support.syncConfig)
+        subject.sync()
+        Assert.assertNull(support.syncConfig)
+        Assert.assertEquals(subject.syncStateSubject.value, DataStore.SyncState.NotSyncing)
+    }
+
+    @Test
     fun testLockUnlock_shouldSync() {
         val stateIterator = this.subject.state.blockingIterable().iterator()
         val listIterator = this.subject.list.blockingIterable().iterator()


### PR DESCRIPTION
Fixes #867 

This PR fixes an obvious dereference of a null pointer. 

We have been unable to reproduce the original crash, but we need to fix this soon.