### PR TITLE
Add telemetry probes to syncIfRequired trigger syncs

### DIFF
--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -129,9 +129,11 @@ open class DataStore(
             if (item != null) {
                 backend.delete(item.id)
                     .asSingle(coroutineContext)
-                    .subscribe()
+                    .subscribe { _ ->
+                        dispatcher.dispatch(DataStoreAction.Sync)
+                    }
                     .addTo(compositeDisposable)
-                sync()
+
                 deletedItemSubject.accept(Consumable(item))
             }
         } catch (loginsStorageException: LoginsStorageException) {
@@ -230,9 +232,12 @@ open class DataStore(
         }
     }
 
-    private fun syncIfRequired() {
+    @VisibleForTesting(
+        otherwise = VisibleForTesting.PRIVATE
+    )
+    fun syncIfRequired() {
         if (timingSupport.shouldSync) {
-            this.sync()
+            dispatcher.dispatch(DataStoreAction.Sync)
             timingSupport.storeNextSyncTime()
         }
     }


### PR DESCRIPTION
Fixes #862

This PR forces `syncIfRequired` to dispatch a `Sync` action, rather than calling the method directly.

This ensures that a sync telemetry event is generated when a timed sync is asked for.