### PR TITLE
791: Remove fake timeout from sync

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/DataStoreAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DataStoreAction.kt
@@ -30,15 +30,6 @@ sealed class DataStoreAction(
     object SyncSuccess : DataStoreAction(TelemetryEventMethod.sync_end, TelemetryEventObject.datastore)
 
     /**
-     * Emitted when the app times out when listening for a response from sync.
-     */
-    data class SyncTimeout(val error: String) : DataStoreAction(
-        TelemetryEventMethod.sync_timeout,
-        TelemetryEventObject.datastore,
-        error
-    )
-
-    /**
      * Emitted when the app receives an error response from sync.
      */
     data class SyncError(val error: String) : DataStoreAction(

--- a/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
@@ -48,7 +48,6 @@ enum class TelemetryEventMethod {
     reset,
     sync_start,
     sync_end,
-    sync_timeout,
     sync_error,
     list_update,
     list_update_error,

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -84,14 +84,6 @@ class ItemListPresenter(
             }
             .addTo(compositeDisposable)
 
-        /* timeout to be fixed in https://github.com/mozilla-lockwise/lockwise-android/issues/791
-              dataStore.syncState
-                  .filter { it == DataStore.SyncState.TimedOut }
-                  .map { R.string.sync_timed_out }
-                  .observeOn(AndroidSchedulers.mainThread())
-                  .subscribe(view::showToastNotification)
-                  .addTo(compositeDisposable)
-        */
         Observables.combineLatest(dataStore.list, settingStore.itemListSortOrder)
             .distinctUntilChanged()
             .map { pair ->

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -23,7 +23,6 @@ object Constant {
         const val appToken = "383z4i46o48w"
 
         val delay: Long = if (isTesting()) 0 else 1
-        val syncTimeout: Long = 20
     }
 
     object FxA {
@@ -34,12 +33,6 @@ object Constant {
         const val profileScope = "profile"
 
         val scopes = setOf(profileScope, lockboxScope, oldSyncScope)
-    }
-
-    object FxAErrors {
-        const val SyncAuthInvalid = "SyncAuthInvalidException"
-        const val InvalidKey = "InvalidKeyException"
-        const val LoginsStorage = "LoginsStorageException"
     }
 
     object Faq {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -253,9 +253,6 @@
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(Kein Benutzername)</string>
 
-    <!-- This is the message displayed when sync has timed out. -->
-    <!--<string name="sync_timed_out">Syncing has timed out</string>-->
-
     <!-- This is the description for the kebab menu in the item detail toolbar. -->
     <string name="kebab_menu">Weitere Optionen</string>
     <!-- This is the text on an item in the item detail toolbar menu to delete an entry. -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -252,7 +252,4 @@
 
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(no existe usuario)</string>
-
-    <!-- This is the message displayed when sync has timed out. -->
-    <!--<string name="sync_timed_out">La sincronización ha expirado</string>-->
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -252,7 +252,7 @@
 
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(no existe usuario)</string>
-    
+
     <!-- This is the message displayed when sync has timed out. -->
     <!--<string name="sync_timed_out">La sincronización ha expirado</string>-->
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -251,9 +251,6 @@
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(aucun nom d’utilisateur)</string>
 
-    <!-- This is the message displayed when sync has timed out. -->
-    <!--<string name="sync_timed_out">Syncing has timed out</string>-->
-
     <!-- This is the description for the kebab menu in the item detail toolbar. -->
     <string name="kebab_menu">Plus d’options</string>
     <!-- This is the text on an item in the item detail toolbar menu to delete an entry. -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -259,9 +259,6 @@
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">[nessun nome utente]</string>
 
-    <!-- This is the message displayed when sync has timed out. -->
-    <!--<string name="sync_timed_out">Syncing has timed out</string>-->
-
     <!-- This is the description for the kebab menu in the item detail toolbar. -->
     <string name="kebab_menu">Altre opzioni</string>
     <!-- This is the text on an item in the item detail toolbar menu to delete an entry. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -257,9 +257,6 @@
     <!-- This is the placeholder text for an empty or null username. -->
     <string name="no_username">(no username)</string>
 
-    <!-- This is the message displayed when sync has timed out. -->
-    <!--<string name="sync_timed_out">Syncing has timed out</string>-->
-
     <!-- This is the description for the kebab menu in the item detail toolbar. -->
     <string name="kebab_menu">More options</string>
     <!-- This is the text on an item in the item detail toolbar menu to delete an entry. -->

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemListPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemListPresenterTest.kt
@@ -327,14 +327,7 @@ open class ItemListPresenterTest {
         syncStateStub.onNext(DataStore.SyncState.NotSyncing)
         Assert.assertEquals(false, view.isLoading)
     }
-    /* timeout to be fixed in https://github.com/mozilla-lockwise/lockwise-android/issues/791
-    @Test
-    fun `sync timeout indicator`() {
-        syncStateStub.onNext(DataStore.SyncState.TimedOut)
-        Assert.assertEquals(false, view.isLoading)
-        Assert.assertEquals(R.string.sync_timed_out, view.toastNotificationArgStrId)
-    }
-    */
+
     @Test
     fun `item deleted toast`() {
         val item = ServerPasswordTestHelper().item1

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -239,7 +239,7 @@ class DataStoreTest : DisposingTest() {
         Assert.assertEquals(expectedSyncUnlockInfo.syncKey, support.syncConfig!!.syncKey)
         Assert.assertEquals(expectedSyncUnlockInfo.tokenserverURL, support.syncConfig!!.tokenserverURL)
     }
-    /* timeout to be fixed in https://github.com/mozilla-lockwise/lockwise-android/issues/791
+
     @Test
     fun testSync() {
         val syncIterator = this.subject.syncState.blockingIterable().iterator()
@@ -247,9 +247,8 @@ class DataStoreTest : DisposingTest() {
 
         dispatcher.dispatch(DataStoreAction.Sync)
         Assert.assertEquals(DataStore.SyncState.Syncing, syncIterator.next())
-        Assert.assertEquals(DataStore.SyncState.TimedOut, syncIterator.next())
     }
-    */
+
     @Test
     fun testGet() {
         val stateIterator = this.subject.state.blockingIterable().iterator()


### PR DESCRIPTION
Fixes #791

## Testing and Review Notes
The toast notification was removed in #833, but the actual logic was still present. This PR removes all of that (if we want a timeout, it should be implemented on the sync side and then handled by us).

## Screenshots or Videos


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] remove ~add~ unit tests
- [ ] ~request the "UX" team perform a design review (if/when applicable)~
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
