### PR TITLE
798: routing back to itemlist on login/search/feedback forms

### DIFF
--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -50,11 +50,11 @@ class LockboxAutofillService(
     lateinit var dataStore: DataStore
 
     override fun onConnected() {
-        dispatcher.dispatch(LifecycleAction.AutofillStart)
         telemetryStore.injectContext(this)
         accountStore.injectContext(this)
         fxaSupport.injectContext(this)
         dataStore = DataStore.shared
+        dispatcher.dispatch(LifecycleAction.AutofillStart)
     }
 
     override fun onDisconnected() {

--- a/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
@@ -103,7 +103,7 @@ sealed class DialogAction(
             R.color.red
         ),
         listOf(
-            ItemDetail(itemId)
+            ItemList
         )
     )
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
@@ -119,10 +119,8 @@ class AppRoutePresenter(
             R.id.fragment_fxa_login to R.id.fragment_autofill_onboarding -> R.id.action_fxaLogin_to_autofill_onboarding
             R.id.fragment_fxa_login to R.id.fragment_onboarding_confirmation -> R.id.action_fxaLogin_to_onboarding_confirmation
 
-            R.id.fragment_fingerprint_onboarding to R.id.fragment_onboarding_confirmation ->
-                R.id.action_fingerprint_onboarding_to_confirmation
-            R.id.fragment_fingerprint_onboarding to R.id.fragment_autofill_onboarding ->
-                R.id.action_onboarding_fingerprint_to_autofill
+            R.id.fragment_fingerprint_onboarding to R.id.fragment_onboarding_confirmation -> R.id.action_fingerprint_onboarding_to_confirmation
+            R.id.fragment_fingerprint_onboarding to R.id.fragment_autofill_onboarding -> R.id.action_onboarding_fingerprint_to_autofill
 
             R.id.fragment_autofill_onboarding to R.id.fragment_item_list -> R.id.action_to_itemList
             R.id.fragment_autofill_onboarding to R.id.fragment_onboarding_confirmation -> R.id.action_autofill_onboarding_to_confirmation
@@ -143,12 +141,19 @@ class AppRoutePresenter(
             R.id.fragment_item_detail to R.id.fragment_webview -> R.id.action_to_webview
             R.id.fragment_item_detail to R.id.fragment_item_list -> R.id.action_to_itemList
             R.id.fragment_item_detail to R.id.fragment_item_edit -> R.id.action_itemDetail_to_edit
+            R.id.fragment_item_detail to R.id.fragment_locked -> R.id.action_itemDetail_to_locked
 
-            R.id.fragment_item_edit to R.id.fragment_item_detail -> R.id.action_itemEdit_to_itemDetail
+            R.id.fragment_item_edit to R.id.fragment_item_list -> R.id.action_itemEdit_to_itemList
+            R.id.fragment_item_edit to R.id.fragment_locked -> R.id.action_itemEdit_to_locked
 
             R.id.fragment_setting to R.id.fragment_webview -> R.id.action_to_webview
+            R.id.fragment_setting to R.id.fragment_locked -> R.id.action_settings_to_locked
 
             R.id.fragment_account_setting to R.id.fragment_welcome -> R.id.action_to_welcome
+
+            R.id.fragment_filter to R.id.fragment_item_detail -> R.id.action_filter_to_itemDetail
+            R.id.fragment_filter to R.id.fragment_item_list -> R.id.action_filter_to_itemList
+            R.id.fragment_filter to R.id.fragment_locked -> R.id.action_filter_to_locked
 
             R.id.fragment_filter_backdrop to R.id.fragment_item_detail -> R.id.action_filter_to_itemDetail
 

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -69,6 +69,8 @@ open class RouteStore(
             .subscribe(onboarding as Relay)
             .addTo(compositeDisposable)
 
+        // dataStore.state is being updated here, and the state it's receiving is Unlocked
+        // causing us to route to the ItemList below
         Observables.combineLatest(dataStore.state, onboarding)
             .filter { !it.second }
             .map { dataStoreToRouteActions(it.first) }

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -69,8 +69,6 @@ open class RouteStore(
             .subscribe(onboarding as Relay)
             .addTo(compositeDisposable)
 
-        // dataStore.state is being updated here, and the state it's receiving is Unlocked
-        // causing us to route to the ItemList below
         Observables.combineLatest(dataStore.state, onboarding)
             .filter { !it.second }
             .map { dataStoreToRouteActions(it.first) }

--- a/app/src/main/res/layout/fragment_filter.xml
+++ b/app/src/main/res/layout/fragment_filter.xml
@@ -13,7 +13,7 @@
     android:backgroundTint="@color/background_grey"
     android:importantForAutofill="noExcludeDescendants"
     tools:context=".view.FilterFragment"
-    tools:ignore="Autofill">
+    tools:ignore="UnusedAttribute">
 
     <include layout="@layout/include_backable_filter"/>
 

--- a/app/src/main/res/layout/fragment_filter.xml
+++ b/app/src/main/res/layout/fragment_filter.xml
@@ -11,12 +11,15 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:backgroundTint="@color/background_grey"
-    tools:context=".view.FilterFragment">
+    android:importantForAutofill="noExcludeDescendants"
+    tools:context=".view.FilterFragment"
+    tools:ignore="Autofill">
 
     <include layout="@layout/include_backable_filter"/>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/entriesView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        tools:ignore="Autofill"/>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -12,7 +12,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:id="@+id/fragment_item_detail"
-        android:background="@color/background_grey" >
+        android:background="@color/background_grey"
+        android:importantForAutofill="noExcludeDescendants">
 
     <include layout="@layout/fragment_warning"
              android:layout_width="match_parent"
@@ -213,7 +214,7 @@
                     card_view:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/inputLayoutUsername"
                     tools:ignore="RtlSymmetry">
-                <androidx.appcompat.widget.AppCompatEditText
+                <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/inputPassword"
                         style="@style/EditTextStyle"
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -13,7 +13,8 @@
         android:layout_height="match_parent"
         android:id="@+id/fragment_item_detail"
         android:background="@color/background_grey"
-        android:importantForAutofill="noExcludeDescendants">
+        android:importantForAutofill="noExcludeDescendants"
+        tools:ignore="UnusedAttribute">
 
     <include layout="@layout/fragment_warning"
              android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_item_edit.xml
+++ b/app/src/main/res/layout/fragment_item_edit.xml
@@ -16,6 +16,7 @@
         android:windowSoftInputMode="adjustPan"
         android:background="@color/background_grey"
         android:importantForAutofill="noExcludeDescendants"
+        tools:ignore="UnusedAttribute"
         style="@style/EditItemDetail" >
 
     <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/fragment_item_edit.xml
+++ b/app/src/main/res/layout/fragment_item_edit.xml
@@ -15,6 +15,7 @@
         android:overScrollMode="ifContentScrolls"
         android:windowSoftInputMode="adjustPan"
         android:background="@color/background_grey"
+        android:importantForAutofill="noExcludeDescendants"
         style="@style/EditItemDetail" >
 
     <androidx.appcompat.widget.Toolbar
@@ -106,7 +107,7 @@
                         card_view:layout_constraintEnd_toEndOf="parent"
                         tools:ignore="RtlSymmetry">
 
-                    <EditText
+                    <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/inputName"
                             style="@style/EditTextStyle"
                             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_webview.xml
+++ b/app/src/main/res/layout/fragment_webview.xml
@@ -14,7 +14,8 @@
         android:id="@+id/fragment_webview"
         android:orientation="vertical"
         android:importantForAutofill="noExcludeDescendants"
-        tools:context=".view.AppWebPageFragment">
+        tools:context=".view.AppWebPageFragment"
+        tools:ignore="UnusedAttribute">
 
     <include layout="@layout/include_backable"
              app:layout_constraintVertical_chainStyle="packed"/>

--- a/app/src/main/res/layout/fragment_webview.xml
+++ b/app/src/main/res/layout/fragment_webview.xml
@@ -13,6 +13,7 @@
         android:layout_height="match_parent"
         android:id="@+id/fragment_webview"
         android:orientation="vertical"
+        android:importantForAutofill="noExcludeDescendants"
         tools:context=".view.AppWebPageFragment">
 
     <include layout="@layout/include_backable"
@@ -31,6 +32,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:overScrollMode="ifContentScrolls"
+            android:importantForAutofill="noExcludeDescendants"
+            tools:ignore="Autofill"
             app:layout_constraintTop_toBottomOf="@id/toolbar"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintVertical_chainStyle="packed"

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -153,6 +153,10 @@
                 app:launchSingleTop="true"
                 app:popUpTo="@id/fragment_item_edit"
                 app:popUpToInclusive="true"/>
+        <action
+                android:id="@+id/action_itemDetail_to_locked"
+                app:destination="@id/fragment_locked"
+                app:popUpToInclusive="true"/>
     </fragment>
 
     <fragment
@@ -164,8 +168,12 @@
                 android:defaultValue="MISSING_ID"
                 app:argType="string"/>
         <action
-                android:id="@+id/action_itemEdit_to_itemDetail"
-                app:destination="@id/fragment_item_detail"
+                android:id="@+id/action_itemEdit_to_itemList"
+                app:destination="@id/fragment_item_list"
+                app:popUpToInclusive="true"/>
+        <action
+                android:id="@+id/action_itemEdit_to_locked"
+                app:destination="@id/fragment_locked"
                 app:popUpToInclusive="true"/>
     </fragment>
 
@@ -174,6 +182,10 @@
             android:name="mozilla.lockbox.view.SettingFragment"
             android:label="@string/nav_menu_settings"
             tools:layout="@layout/fragment_setting">
+        <action
+                android:id="@+id/action_settings_to_locked"
+                app:destination="@id/fragment_locked"
+                app:popUpToInclusive="true"/>
     </fragment>
 
     <fragment
@@ -203,6 +215,13 @@
         <action
                 android:id="@+id/action_filter_to_itemDetail"
                 app:destination="@id/fragment_item_detail"/>
+        <action
+                android:id="@+id/action_filter_to_itemList"
+                app:destination="@id/fragment_item_list"/>
+        <action
+                android:id="@+id/action_filter_to_locked"
+                app:destination="@id/fragment_locked"
+                app:popUpToInclusive="true"/>
     </fragment>
 
     <fragment


### PR DESCRIPTION
Fixes #798 

There are a number of things that are being cleaned up as part of this PR. The original issue was tracking the keyboard being minimized when clicking in text fields, and in some cases, being routed back to the item list. 

Below you will find my notes and analysis which lead me to find the source of the original issue: the AutofillService was being triggered when a potentially fillable text field was encountered (e.g. the search text field or editable username/hostname/password fields). The mitigation for this was to mark those fields as _not_ autofillable.

In addition to that, this PR fixes the following:
- dispatch the `AutofillStart` action at the end of `onConnect()` instead of the beginning
- add missing routes for locking that caused crashes
- use `TextInputEditText` in place of `EditText`


-------------

## Testing and Review Notes
This is easily reproducible on Pixel 2 with search and edit.

### Search

~Probably related to locking or routing...~ we're seeing the `DataStore.state` being updated, which causes the `Unlocked` workflow to send the user to the ItemList: 
```
private fun dataStoreToRouteActions(storageState: DataStore.State): Optional<RouteAction> {
        return when (storageState) {
            is DataStore.State.Unlocked -> RouteAction.ItemList
            is DataStore.State.Locked -> RouteAction.LockScreen
            is DataStore.State.Unprepared -> RouteAction.Welcome
            else -> null
        }.asOptional()
    }
```

The state could be set to `Unlocked` in three places in the `DataStore`:
- `updateCredentials()`
- `unlock()` - coming from `FingerprintAuthAction` in the `LockedPresenter`
- `handleLock()`

Todo: 
- [x] add route from `fragment_filter` -> `fragment_locked`
- [x] add route from `fragment_filter` -> `fragment_item_list` (does this solve the issue?)

### Edit
```     
Caused by: java.lang.IllegalStateException: Cannot route from mozilla.lockbox:id/fragment_item_edit to mozilla.lockbox:id/fragment_locked. This is a developer bug, fixable by adding an action to mozilla.lockbox:id/graph_main.xml and/or AppRoutePresenter
        at mozilla.lockbox.presenter.RoutePresenter.navigateToFragment(RoutePresenter.kt:145)
        at mozilla.lockbox.presenter.RoutePresenter.navigateToFragment$default(RoutePresenter.kt:125)
        at mozilla.lockbox.presenter.AppRoutePresenter.route(AppRoutePresenter.kt:90)
        at mozilla.lockbox.presenter.AppRoutePresenter$onResume$1.invoke(AppRoutePresenter.kt:52)
        at mozilla.lockbox.presenter.AppRoutePresenter$onResume$1.invoke(AppRoutePresenter.kt:32)
```

Todo:
- [x] add route from `fragment_item_edit` -> `fragment_locked`
<img width="654" alt="image" src="https://user-images.githubusercontent.com/43795363/64377909-1d784500-cff1-11e9-8643-3b7f750d5bcc.png">
