### PR TITLE
Fix up dialogs being added to history.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
@@ -11,6 +11,15 @@ import mozilla.lockbox.R
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.model.DialogViewModel
 
+/**
+ * Dispatching a `DialogAction` causes a modal dialog to be displayed.
+ *
+ * On the user pressing either a the positive or negative buttons a list of actions
+ * are dispatched.
+ *
+ * Hint: DialogActions are not added to history stack. The edge linking where the dialog is shown to where
+ * then buttons should take the user should be represented in the `RoutePresenter` and the `graph.xml`.
+ */
 sealed class DialogAction(
     val viewModel: DialogViewModel,
     val positiveButtonActionList: List<Action> = emptyList(),

--- a/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
@@ -132,6 +132,7 @@ class AppRoutePresenter(
             R.id.fragment_item_list to R.id.fragment_webview -> R.id.action_to_webview
 
             R.id.fragment_item_detail to R.id.fragment_webview -> R.id.action_to_webview
+            R.id.fragment_item_detail to R.id.fragment_item_list -> R.id.action_to_itemList
 
             R.id.fragment_setting to R.id.fragment_webview -> R.id.action_to_webview
 

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -19,6 +19,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavController
 import io.reactivex.rxkotlin.addTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.lockbox.BuildConfig
 import mozilla.lockbox.R
 import mozilla.lockbox.action.DialogAction
 import mozilla.lockbox.action.RouteAction
@@ -137,13 +138,15 @@ abstract class RoutePresenter(
         val navOptions = if (transition == destinationId) {
             // Without being able to detect if we're in developer mode,
             // it is too dangerous to RuntimeException.
-            val from = activity.resources.getResourceName(srcId)
-            val to = activity.resources.getResourceName(destinationId)
-            val graphName = activity.resources.getResourceName(navController.graph.id)
-            log.error(
-                "Cannot route from $from to $to. " +
-                    "This is a developer bug, fixable by adding an action to $graphName.xml and/or ${javaClass.simpleName}"
-            )
+            if (BuildConfig.DEBUG) {
+                val from = activity.resources.getResourceName(srcId)
+                val to = activity.resources.getResourceName(destinationId)
+                val graphName = activity.resources.getResourceName(navController.graph.id)
+                throw IllegalStateException(
+                    "Cannot route from $from to $to. " +
+                        "This is a developer bug, fixable by adding an action to $graphName.xml and/or ${javaClass.simpleName}"
+                )
+            }
             null
         } else {
             // Get the transition action out of the graph, before we manually clear the back


### PR DESCRIPTION
Fixes #804

This PR is the simplest fix to #804.

 * Add a route in the `AppRoutePresenter` from item detail to item list.
 * Fail fast if the edge between to routes is not in the nav graph. This is only enabled in debug builds.
 * API docs to warn future folks.
 * opened additional bugs #896 and #897 for follow up chores.

Investigation is detailed in [a comment in 804][1].

[1]: https://github.com/mozilla-lockwise/lockwise-android/issues/804#issuecomment-526396401