### PR TITLE
Cache access tokens

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/uiTests/AutoLockTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/uiTests/AutoLockTest.kt
@@ -12,25 +12,13 @@ import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.robots.itemList
 import mozilla.lockbox.support.TimingSupport
 import mozilla.lockbox.support.SystemTimingSupport
+import mozilla.lockbox.support.TestSystemTimingSupport
 import mozilla.lockbox.view.RootActivity
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-
-@Ignore("589-UItests-update (#590)")
-class TestSystemTimingSupport() : SystemTimingSupport {
-    override var systemTimeElapsed: Long = 0L
-
-    constructor(existing: SystemTimingSupport) : this() {
-        systemTimeElapsed = existing.systemTimeElapsed
-    }
-
-    fun advance(time: Long = 1L) {
-        systemTimeElapsed += time
-    }
-}
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)

--- a/app/src/androidTest/java/mozilla/lockbox/uiTests/AutoLockTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/uiTests/AutoLockTest.kt
@@ -11,7 +11,6 @@ import mozilla.lockbox.action.Setting
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.robots.itemList
 import mozilla.lockbox.support.TimingSupport
-import mozilla.lockbox.support.SystemTimingSupport
 import mozilla.lockbox.support.TestSystemTimingSupport
 import mozilla.lockbox.view.RootActivity
 import org.junit.Before

--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -49,16 +49,16 @@ class LockboxAutofillService(
     private val pslSupport = PublicSuffixSupport.shared
     lateinit var dataStore: DataStore
 
+    var isRunning = false
+
     override fun onConnected() {
-        telemetryStore.injectContext(this)
-        accountStore.injectContext(this)
-        fxaSupport.injectContext(this)
-        dataStore = DataStore.shared
-        dispatcher.dispatch(LifecycleAction.AutofillStart)
+        isRunning = false
     }
 
     override fun onDisconnected() {
-        dispatcher.dispatch(LifecycleAction.AutofillEnd)
+        if (isRunning) {
+            dispatcher.dispatch(LifecycleAction.AutofillEnd)
+        }
         compositeDisposable.clear()
     }
 
@@ -81,6 +81,13 @@ class LockboxAutofillService(
             callback.onSuccess(null)
             return
         }
+
+        isRunning = true
+        telemetryStore.injectContext(this)
+        accountStore.injectContext(this)
+        fxaSupport.injectContext(this)
+        dataStore = DataStore.shared
+        dispatcher.dispatch(LifecycleAction.AutofillStart)
 
         val builder = FillResponseBuilder(parsedStructure)
 

--- a/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
@@ -167,6 +167,10 @@ class AppRoutePresenter(
             R.id.fragment_filter to R.id.fragment_item_list -> R.id.action_filter_to_itemList
 
             else -> null
+        } ?: when (dest) {
+            R.id.fragment_locked -> R.id.action_to_locked
+
+            else -> null
         }
     }
 

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -308,8 +308,7 @@ open class AccountStore(
 
         tokenRotationHandler.removeCallbacksAndMessages(null)
 
-        this.securePreferences.remove(Constant.Key.firefoxAccount)
-        this.securePreferences.remove(Constant.Key.accessToken)
+        this.securePreferences.clear()
 
         this.generateNewFirefoxAccount()
 

--- a/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
@@ -20,11 +20,11 @@ import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.support.ClipboardSupport
 import mozilla.lockbox.support.Constant
 import mozilla.lockbox.support.SystemTimingSupport
-import mozilla.lockbox.support.SystemSystemTimingSupport
+import mozilla.lockbox.support.DeviceSystemTimingSupport
 
 open class ClipboardStore(
     val dispatcher: Dispatcher = Dispatcher.shared,
-    private val timerSupport: SystemTimingSupport = SystemSystemTimingSupport()
+    private val timerSupport: SystemTimingSupport = DeviceSystemTimingSupport()
 ) : ContextStore {
     internal val compositeDisposable = CompositeDisposable()
 

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -69,6 +69,7 @@ object Constant {
         const val bootCompletedIntent = "android.intent.action.BOOT_COMPLETED"
         const val clearClipboardIntent = "mozilla.lockbox.intent.CLEAR_CLIPBOARD"
         const val clipboardDirtyExtra = "clipboard-dirty"
+        const val accessToken = "access-token"
     }
 
     object FingerprintTimeout {

--- a/app/src/main/java/mozilla/lockbox/support/SecurePreferences.kt
+++ b/app/src/main/java/mozilla/lockbox/support/SecurePreferences.kt
@@ -75,9 +75,10 @@ open class SecurePreferences(
         editor.apply()
     }
 
-    open fun clear() {
-        prefs.edit().clear().commit()
-    }
+    open fun clear() = prefs
+            .edit()
+            .clear()
+            .apply()
 
     // these methods won't be used until https://github.com/mozilla-lockwise/lockwise-android/issues/165
     // is addressed.

--- a/app/src/main/java/mozilla/lockbox/support/SecurePreferences.kt
+++ b/app/src/main/java/mozilla/lockbox/support/SecurePreferences.kt
@@ -75,6 +75,10 @@ open class SecurePreferences(
         editor.apply()
     }
 
+    open fun clear() {
+        prefs.edit().clear().commit()
+    }
+
     // these methods won't be used until https://github.com/mozilla-lockwise/lockwise-android/issues/165
     // is addressed.
 //    open fun createEncryptCipher(): Cipher {

--- a/app/src/main/java/mozilla/lockbox/support/SystemTimingSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/SystemTimingSupport.kt
@@ -4,9 +4,32 @@ import android.os.SystemClock
 
 interface SystemTimingSupport {
     val systemTimeElapsed: Long
+    val currentTimeMillis: Long
 }
 
-class SystemSystemTimingSupport : SystemTimingSupport {
+class DeviceSystemTimingSupport : SystemTimingSupport {
+    companion object {
+        val shared = DeviceSystemTimingSupport()
+    }
+
     override val systemTimeElapsed: Long
         get() = SystemClock.elapsedRealtime()
+
+    override val currentTimeMillis: Long
+        get() = System.currentTimeMillis()
+}
+
+class TestSystemTimingSupport() : SystemTimingSupport {
+    override var systemTimeElapsed: Long = 0L
+    override var currentTimeMillis: Long = 0L
+
+    constructor(existing: SystemTimingSupport) : this() {
+        systemTimeElapsed = existing.systemTimeElapsed
+        currentTimeMillis = existing.currentTimeMillis
+    }
+
+    fun advance(time: Long = 1L) {
+        systemTimeElapsed += time
+        currentTimeMillis += time
+    }
 }

--- a/app/src/main/java/mozilla/lockbox/support/TimingSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/TimingSupport.kt
@@ -28,7 +28,7 @@ open class TimingSupport(
     private val compositeDisposable = CompositeDisposable()
     private lateinit var preferences: SharedPreferences
 
-    var systemTimingSupport: SystemTimingSupport = SystemSystemTimingSupport()
+    var systemTimingSupport: SystemTimingSupport = DeviceSystemTimingSupport()
 
     open val shouldLock: Boolean
         get() = lockCurrentlyRequired()

--- a/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
@@ -32,6 +32,7 @@ import org.mockito.Mockito.`when` as whenCalled
 @Ignore("More reliably clear the clipboard (#644)")
 class TestSystemTimeSupport : SystemTimingSupport {
     override val systemTimeElapsed: Long = 2000L
+    override val currentTimeMillis: Long = 2000L
 }
 
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/mozilla/lockbox/support/TimingSupportTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/TimingSupportTest.kt
@@ -35,10 +35,6 @@ import org.powermock.modules.junit4.PowerMockRunner
 import java.lang.Math.abs
 import org.mockito.Mockito.`when` as whenCalled
 
-class TestSystemTimingSupport : SystemTimingSupport {
-    override var systemTimeElapsed: Long = 0L
-}
-
 @ExperimentalCoroutinesApi
 @RunWith(PowerMockRunner::class)
 @PrepareForTest(PreferenceManager::class, SimpleFileReader::class)


### PR DESCRIPTION
Fixes #941 

This PR introduces 

 * access token caching. 
 * token rotation after expiry.
 * lazy initialization of the account store during `Autofill`.

~Currently still in WIP because it hasn't passed enough smoke tests.~ Edit: fixed by `clear`ing secure preferences once the account is disconnected.

PR opened to get feedback.