### PR TITLE
[DO NOT MERGE] Caching access tokens

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/uiTests/AutoLockTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/uiTests/AutoLockTest.kt
@@ -11,26 +11,13 @@ import mozilla.lockbox.action.Setting
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.robots.itemList
 import mozilla.lockbox.support.TimingSupport
-import mozilla.lockbox.support.SystemTimingSupport
+import mozilla.lockbox.support.TestSystemTimingSupport
 import mozilla.lockbox.view.RootActivity
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-
-@Ignore("589-UItests-update (#590)")
-class TestSystemTimingSupport() : SystemTimingSupport {
-    override var systemTimeElapsed: Long = 0L
-
-    constructor(existing: SystemTimingSupport) : this() {
-        systemTimeElapsed = existing.systemTimeElapsed
-    }
-
-    fun advance(time: Long = 1L) {
-        systemTimeElapsed += time
-    }
-}
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)

--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -49,16 +49,16 @@ class LockboxAutofillService(
     private val pslSupport = PublicSuffixSupport.shared
     lateinit var dataStore: DataStore
 
+    var isRunning = false
+
     override fun onConnected() {
-        telemetryStore.injectContext(this)
-        accountStore.injectContext(this)
-        fxaSupport.injectContext(this)
-        dataStore = DataStore.shared
-        dispatcher.dispatch(LifecycleAction.AutofillStart)
+        isRunning = false
     }
 
     override fun onDisconnected() {
-        dispatcher.dispatch(LifecycleAction.AutofillEnd)
+        if (isRunning) {
+            dispatcher.dispatch(LifecycleAction.AutofillEnd)
+        }
         compositeDisposable.clear()
     }
 
@@ -81,6 +81,13 @@ class LockboxAutofillService(
             callback.onSuccess(null)
             return
         }
+
+        isRunning = true
+        telemetryStore.injectContext(this)
+        accountStore.injectContext(this)
+        fxaSupport.injectContext(this)
+        dataStore = DataStore.shared
+        dispatcher.dispatch(LifecycleAction.AutofillStart)
 
         val builder = FillResponseBuilder(parsedStructure)
 

--- a/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
@@ -167,6 +167,10 @@ class AppRoutePresenter(
             R.id.fragment_filter to R.id.fragment_item_list -> R.id.action_filter_to_itemList
 
             else -> null
+        } ?: when (dest) {
+            R.id.fragment_locked -> R.id.action_to_locked
+
+            else -> null
         }
     }
 

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -8,6 +8,7 @@ package mozilla.lockbox.store
 
 import android.content.Context
 import android.net.Uri
+import android.os.Handler
 import android.os.Looper
 import android.webkit.CookieManager
 import android.webkit.WebStorage
@@ -25,6 +26,7 @@ import kotlinx.coroutines.rx2.asSingle
 import mozilla.appservices.fxaclient.FxaException
 import mozilla.components.concept.sync.AccessTokenInfo
 import mozilla.components.concept.sync.Avatar
+import mozilla.components.concept.sync.OAuthScopedKey
 import mozilla.components.concept.sync.Profile
 import mozilla.components.service.fxa.FirefoxAccount
 import mozilla.components.service.fxa.ServerConfig
@@ -41,10 +43,14 @@ import mozilla.lockbox.model.FixedSyncCredentials
 import mozilla.lockbox.model.FxASyncCredentials
 import mozilla.lockbox.model.SyncCredentials
 import mozilla.lockbox.support.Constant
+import mozilla.lockbox.support.DeviceSystemTimingSupport
 import mozilla.lockbox.support.Optional
 import mozilla.lockbox.support.SecurePreferences
+import mozilla.lockbox.support.SystemTimingSupport
 import mozilla.lockbox.support.asOptional
+import org.json.JSONObject
 import java.io.File
+import java.lang.Long.min
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
@@ -52,7 +58,8 @@ import kotlin.coroutines.CoroutineContext
 open class AccountStore(
     private val lifecycleStore: LifecycleStore = LifecycleStore.shared,
     private val dispatcher: Dispatcher = Dispatcher.shared,
-    private val securePreferences: SecurePreferences = SecurePreferences.shared
+    private val securePreferences: SecurePreferences = SecurePreferences.shared,
+    private val timingSupport: SystemTimingSupport = DeviceSystemTimingSupport.shared
 ) : ContextStore {
     companion object {
         val shared by lazy { AccountStore() }
@@ -94,6 +101,8 @@ open class AccountStore(
     private lateinit var webView: WebView
     private lateinit var logDirectory: File
     private lateinit var context: Context
+
+    private val tokenRotationHandler = Handler()
 
     init {
         val resetObservable = lifecycleStore.lifecycleEvents
@@ -183,7 +192,7 @@ open class AccountStore(
 
     private fun populateAccountInformation(isNew: Boolean) {
         val profileSubject = profile as Subject
-        val syncCredentialSubject = syncCredentials as Subject
+
         val fxa = fxa ?: return
         securePreferences.putString(Constant.Key.firefoxAccount, fxa.toJSONString())
 
@@ -194,14 +203,54 @@ open class AccountStore(
             .subscribe(profileSubject::onNext, this::pushError)
             .addTo(compositeDisposable)
 
+        val token = securePreferences.getString(Constant.Key.accessToken)?.let {
+            accessTokenInfoFromJSON(JSONObject(it))
+        }
+
+        token?.let { handleAccessToken(it, isNew) } ?: tokenRotationHandler.post { fetchFreshToken(isNew) }
+    }
+
+    private fun fetchFreshToken(isNewLogin: Boolean = false) {
+        val fxa = fxa ?: return
         fxa.getAccessTokenAsync(Constant.FxA.oldSyncScope)
             .asMaybe(coroutineContext)
             .delay(1L, TimeUnit.SECONDS)
-            .map {
-                generateSyncCredentials(it, isNew).asOptional()
-            }
-            .subscribe(syncCredentialSubject::onNext, this::pushError)
+            .subscribe({ token ->
+                handleAccessToken(token, isNewLogin)
+            }, this::pushError)
             .addTo(compositeDisposable)
+    }
+
+    private fun handleAccessToken(
+        token: AccessTokenInfo,
+        isNewLogin: Boolean
+    ) {
+        // We've just got a new token. It might be from secure preferences (we've just been
+        // restarted) or a token refresh.
+        // 1. Update the rest of the app.
+        val credentials = generateSyncCredentials(token, isNewLogin)
+        val syncCredentialSubject = syncCredentials as Subject
+        syncCredentialSubject.onNext(credentials.asOptional())
+
+        // 2. Store this token in the secure preferences.
+        securePreferences.putString(Constant.Key.accessToken, token.toJSONObject().toString())
+
+        // 3. Schedule a token refresh. It may be quite a long time away.
+        // Calculate how long before the token expires in milliseconds.
+        val msDelay = token.expiresAt * 1000L - timingSupport.currentTimeMillis
+
+        // We'll wait until it's almost expired, leaving at most 10 minutes to fetch the token.
+        val refreshMargin = min(msDelay * 95L / 100L, 10 * 60 * 1000L)
+
+        // Wait until the token has nearly expired, and then fetch a new one.
+        scheduleFetchFreshToken(msDelay - refreshMargin)
+    }
+
+    private fun scheduleFetchFreshToken(msDelay: Long) {
+        // If the app is killed, then this will be refreshed when the app is restarted.
+        tokenRotationHandler.postDelayed({
+            fetchFreshToken(false)
+        }, msDelay)
     }
 
     private fun generateSyncCredentials(oauthInfo: AccessTokenInfo, isNew: Boolean): SyncCredentials? {
@@ -257,7 +306,10 @@ open class AccountStore(
             WebStorage.getInstance().deleteAllData()
         }
 
-        this.securePreferences.remove(Constant.Key.firefoxAccount)
+        tokenRotationHandler.removeCallbacksAndMessages(null)
+
+        this.securePreferences.clear()
+
         this.generateNewFirefoxAccount()
 
         webView.clearCache(true)
@@ -318,4 +370,34 @@ open class AccountStore(
 
         dispatcher.dispatch(SentryAction(it))
     }
+}
+
+private fun AccessTokenInfo.toJSONObject() = JSONObject()
+        .put("scope", scope)
+        .put("token", token)
+        .put("expiresAt", expiresAt)
+        .put("key", key?.toJSONObject())
+
+private fun OAuthScopedKey.toJSONObject() = JSONObject()
+        .put("kty", kty)
+        .put("scope", scope)
+        .put("kid", kid)
+        .put("k", k)
+
+private fun accessTokenInfoFromJSON(obj: JSONObject): AccessTokenInfo? {
+    return AccessTokenInfo(
+        scope = obj.optString("scope", null) ?: return null,
+        token = obj.optString("token", null) ?: return null,
+        expiresAt = obj.optLong("expiresAt", 0L),
+        key = obj.optJSONObject("key")?.let { oauthScopedKeyFromJSON(it) }
+    )
+}
+
+private fun oauthScopedKeyFromJSON(obj: JSONObject): OAuthScopedKey? {
+    return OAuthScopedKey(
+        kty = obj.optString("kty", null) ?: return null,
+        scope = obj.optString("scope", null) ?: return null,
+        kid = obj.optString("kid", null) ?: return null,
+        k = obj.optString("k", null) ?: return null
+    )
 }

--- a/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
@@ -20,11 +20,11 @@ import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.support.ClipboardSupport
 import mozilla.lockbox.support.Constant
 import mozilla.lockbox.support.SystemTimingSupport
-import mozilla.lockbox.support.SystemSystemTimingSupport
+import mozilla.lockbox.support.DeviceSystemTimingSupport
 
 open class ClipboardStore(
     val dispatcher: Dispatcher = Dispatcher.shared,
-    private val timerSupport: SystemTimingSupport = SystemSystemTimingSupport()
+    private val timerSupport: SystemTimingSupport = DeviceSystemTimingSupport()
 ) : ContextStore {
     internal val compositeDisposable = CompositeDisposable()
 

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -75,6 +75,7 @@ object Constant {
         const val bootCompletedIntent = "android.intent.action.BOOT_COMPLETED"
         const val clearClipboardIntent = "mozilla.lockbox.intent.CLEAR_CLIPBOARD"
         const val clipboardDirtyExtra = "clipboard-dirty"
+        const val accessToken = "access-token"
     }
 
     object FingerprintTimeout {

--- a/app/src/main/java/mozilla/lockbox/support/SecurePreferences.kt
+++ b/app/src/main/java/mozilla/lockbox/support/SecurePreferences.kt
@@ -75,6 +75,11 @@ open class SecurePreferences(
         editor.apply()
     }
 
+    open fun clear() = prefs
+            .edit()
+            .clear()
+            .apply()
+
     // these methods won't be used until https://github.com/mozilla-lockwise/lockwise-android/issues/165
     // is addressed.
 //    open fun createEncryptCipher(): Cipher {

--- a/app/src/main/java/mozilla/lockbox/support/SystemTimingSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/SystemTimingSupport.kt
@@ -4,9 +4,32 @@ import android.os.SystemClock
 
 interface SystemTimingSupport {
     val systemTimeElapsed: Long
+    val currentTimeMillis: Long
 }
 
-class SystemSystemTimingSupport : SystemTimingSupport {
+class DeviceSystemTimingSupport : SystemTimingSupport {
+    companion object {
+        val shared = DeviceSystemTimingSupport()
+    }
+
     override val systemTimeElapsed: Long
         get() = SystemClock.elapsedRealtime()
+
+    override val currentTimeMillis: Long
+        get() = System.currentTimeMillis()
+}
+
+class TestSystemTimingSupport() : SystemTimingSupport {
+    override var systemTimeElapsed: Long = 0L
+    override var currentTimeMillis: Long = 0L
+
+    constructor(existing: SystemTimingSupport) : this() {
+        systemTimeElapsed = existing.systemTimeElapsed
+        currentTimeMillis = existing.currentTimeMillis
+    }
+
+    fun advance(time: Long = 1L) {
+        systemTimeElapsed += time
+        currentTimeMillis += time
+    }
 }

--- a/app/src/main/java/mozilla/lockbox/support/TimingSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/TimingSupport.kt
@@ -28,7 +28,7 @@ open class TimingSupport(
     private val compositeDisposable = CompositeDisposable()
     private lateinit var preferences: SharedPreferences
 
-    var systemTimingSupport: SystemTimingSupport = SystemSystemTimingSupport()
+    var systemTimingSupport: SystemTimingSupport = DeviceSystemTimingSupport()
 
     open val shouldLock: Boolean
         get() = lockCurrentlyRequired()

--- a/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
@@ -32,6 +32,7 @@ import org.mockito.Mockito.`when` as whenCalled
 @Ignore("More reliably clear the clipboard (#644)")
 class TestSystemTimeSupport : SystemTimingSupport {
     override val systemTimeElapsed: Long = 2000L
+    override val currentTimeMillis: Long = 2000L
 }
 
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/mozilla/lockbox/support/TimingSupportTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/TimingSupportTest.kt
@@ -35,10 +35,6 @@ import org.powermock.modules.junit4.PowerMockRunner
 import java.lang.Math.abs
 import org.mockito.Mockito.`when` as whenCalled
 
-class TestSystemTimingSupport : SystemTimingSupport {
-    override var systemTimeElapsed: Long = 0L
-}
-
 @ExperimentalCoroutinesApi
 @RunWith(PowerMockRunner::class)
 @PrepareForTest(PreferenceManager::class, SimpleFileReader::class)


### PR DESCRIPTION
* Add token caching and token rotation.
* Additional routing to allow locking to come at any time.
* Only start up the stores a login page is detected.
* Rename and simplify SystemTimingSupport
* Clear preferences on disconnecting the Firefox account
* gradlew check

