### PR TITLE
938-uitests-add-error-handling-edit-view

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/robots/EditCredentialRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/EditCredentialRobot.kt
@@ -22,12 +22,13 @@ class EditCredentialRobot : BaseTestRobot {
     fun closeEditChanges() = ClickActions.click { contentDescription("Back") }
     fun deleteEntryFromEdit() = ClickActions.click { id(R.id.deleteEntryButton) }
 
-    fun tapOnHostname() = onView(withId(R.id.inputHostname)).perform(click())
-    fun editHostname(text: String) = onView(withId(R.id.inputHostname)).perform(replaceText(text))
     fun tapOnUserName() = onView(withId(R.id.inputUsername)).perform(click())
     fun editUserName(text: String) = onView(withId(R.id.inputUsername)).perform(replaceText(text))
 
     fun editPassword(text: String) = onView(withId(R.id.inputPassword)).perform(replaceText(text))
+    fun removePassword(text: String) = onView(withId(R.id.inputPassword)).perform(replaceText(text))
+    fun assertErrorEmptyPassord() = VisibilityAssertions.displayed { id(R.id.textinput_error) }
+    fun noErrorEmptyPassword() = VisibilityAssertions.notDisplayed { id(R.id.textinput_error) }
 }
 
 fun editCredential(f: EditCredentialRobot.() -> Unit) = EditCredentialRobot().apply(f)

--- a/app/src/androidTest/java/mozilla/lockbox/robots/EditCredentialRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/EditCredentialRobot.kt
@@ -26,7 +26,6 @@ class EditCredentialRobot : BaseTestRobot {
     fun editUserName(text: String) = onView(withId(R.id.inputUsername)).perform(replaceText(text))
 
     fun editPassword(text: String) = onView(withId(R.id.inputPassword)).perform(replaceText(text))
-    fun removePassword(text: String) = onView(withId(R.id.inputPassword)).perform(replaceText(text))
     fun assertErrorEmptyPassord() = VisibilityAssertions.displayed { id(R.id.textinput_error) }
     fun noErrorEmptyPassword() = VisibilityAssertions.notDisplayed { id(R.id.textinput_error) }
 }

--- a/app/src/androidTest/java/mozilla/lockbox/uiTests/ItemDetailsTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/uiTests/ItemDetailsTest.kt
@@ -67,17 +67,14 @@ open class ItemDetailsTest {
         // Edit entry Hostname and Username
         editCredential {
             exists()
-            tapOnHostname()
-            editHostname("HostnameChanged")
             tapOnUserName()
             editUserName("UsernameChanged")
             saveChanges() }
         // Check that changes in entry are saved
         itemList {
             exists()
-            editedCredentialHostnameExists("HostnameChanged")
             editedCredentialUsernameExists("UsernameChanged")
-            openCredential("HostnameChanged")
+            openCredential("UsernameChanged")
         }
         // Remove the entry
         navigator.gotoItemDetailKebabMenu()
@@ -115,5 +112,17 @@ open class ItemDetailsTest {
         // User is taken to ItemList View
         // No changes are applied
         itemList { exists() }
+    }
+
+    @Test
+    fun editItemInvalidTextFieldInput() {
+        navigator.gotoItemDetailKebabMenu()
+        kebabMenu { tapEditButton() }
+        editCredential {
+            editPassword("")
+            assertErrorEmptyPassord()
+            editPassword("foo")
+            noErrorEmptyPassword()
+        }
     }
 }


### PR DESCRIPTION
Fixes #938
This PR adds the test for checking  that password can't be empty and that there is an error shown when that happens. 

Also it is removing the edit/checking of the hostname as according to issue #956 it will be disabled soon