### PR TITLE
Add intent filter for launching app from a URL

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,13 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="lockwise" />
+            </intent-filter>
         </activity>
         <activity android:name=".view.AutofillRootActivity"
                   android:configChanges="orientation|keyboardHidden"


### PR DESCRIPTION
Fixes #955.

This PR allows the app to be opened from a URL with a `lockwise` scheme. This makes it compatible with Adjust, and thence Bento. 