### PR TITLE
UX cleanup for item detail and edit view long usernames/hostnames/passwords

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/robots/EditCredentialRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/EditCredentialRobot.kt
@@ -20,7 +20,6 @@ class EditCredentialRobot : BaseTestRobot {
 
     fun saveChanges() = ClickActions.click { id(R.id.saveEntryButton) }
     fun closeEditChanges() = ClickActions.click { contentDescription("Back") }
-    fun deleteEntryFromEdit() = ClickActions.click { id(R.id.deleteEntryButton) }
 
     fun tapOnUserName() = onView(withId(R.id.inputUsername)).perform(click())
     fun editUserName(text: String) = onView(withId(R.id.inputUsername)).perform(replaceText(text))

--- a/app/src/androidTest/java/mozilla/lockbox/uiTests/ItemDetailsTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/uiTests/ItemDetailsTest.kt
@@ -76,23 +76,6 @@ open class ItemDetailsTest {
             editedCredentialUsernameExists("UsernameChanged")
             openCredential("UsernameChanged")
         }
-        // Remove the entry
-        navigator.gotoItemDetailKebabMenu()
-        kebabMenu { tapEditButton() }
-        editCredential { deleteEntryFromEdit() }
-        // Tap on Cancel
-        deleteCredentialDisclaimer { tapCancelButton() }
-        editCredential {
-            exists()
-            // Tap on Delete
-            deleteEntryFromEdit()
-        }
-        deleteCredentialDisclaimer { tapDeleteButton() }
-        // Once entry is removed user is taken to ItemList view
-        itemList {
-            exists()
-            credentialRemovedDoesNotExist("HostnameChanged")
-        }
     }
 
     @Test

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -33,7 +33,6 @@ interface EditItemDetailView {
     var isPasswordVisible: Boolean
     val togglePasswordClicks: Observable<Unit>
     val togglePasswordVisibility: Observable<Unit>
-    val deleteClicks: Observable<Unit>
     val closeEntryClicks: Observable<Unit>
     val saveEntryClicks: Observable<Unit>
     val hostnameChanged: Observable<String>
@@ -100,17 +99,6 @@ class EditItemPresenter(
             .subscribe {
                 dispatcher.dispatch(
                     ItemDetailAction.SetPasswordVisibility(view.isPasswordVisible.not())
-                )
-            }
-            .addTo(compositeDisposable)
-
-        view.deleteClicks
-            .subscribe {
-                credentials?.let {
-                    dispatcher.dispatch(DialogAction.DeleteConfirmationDialog(it))
-                } ?: pushError(
-                    NullPointerException("Credentials are null"),
-                    "Error editing credential with id ${credentials?.id}"
                 )
             }
             .addTo(compositeDisposable)

--- a/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
@@ -41,9 +41,6 @@ class EditItemFragment : BackableFragment(), EditItemDetailView {
     override val togglePasswordClicks: Observable<Unit>
         get() = view!!.btnPasswordToggle.clicks()
 
-    override val deleteClicks: Observable<Unit>
-        get() = view!!.deleteEntryButton.clicks()
-
     override val closeEntryClicks: Observable<Unit>
         get() = view!!.toolbar.navigationClicks()
 

--- a/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
@@ -208,6 +208,9 @@ class EditItemFragment : BackableFragment(), EditItemDetailView {
         inputPassword.isClickable = true
 
         inputName.setText(item.hostname, TextView.BufferType.NORMAL)
+        inputName.setSingleLine()
+        inputName.ellipsize = TextUtils.TruncateAt.END
+
         inputHostname.setText(item.hostname, TextView.BufferType.NORMAL)
         inputPassword.setText(item.password, TextView.BufferType.NORMAL)
 

--- a/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
@@ -8,6 +8,7 @@ package mozilla.lockbox.view
 
 import android.content.Context
 import android.os.Bundle
+import android.text.TextUtils
 import android.text.method.PasswordTransformationMethod
 import android.view.Gravity
 import android.view.LayoutInflater

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -151,12 +151,6 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         inputLayoutPassword.isHintAnimationEnabled = false
         inputLayoutUsername.isScrollContainer = false
         view?.isScrollContainer = false
-//        inputPassword.stopNestedScroll()
-//        inputPassword.setHorizontallyScrolling(false)
-//        inputPassword.setSingleLine()
-//        inputPassword.isScrollContainer = false
-//        inputPassword.ellipsize = TextUtils.TruncateAt.END
-//        inputPassword.maxLines = 1
 
         inputUsername.readOnly = true
         inputLayoutUsername.editText?.ellipsize = TextUtils.TruncateAt.END

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -149,12 +149,20 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         inputLayoutHostname.isHintAnimationEnabled = false
         inputLayoutUsername.isHintAnimationEnabled = false
         inputLayoutPassword.isHintAnimationEnabled = false
-
-        inputPassword.ellipsize = TextUtils.TruncateAt.END
-        inputPassword.setSingleLine()
-        inputPassword.maxLines = 1
+        inputLayoutUsername.isScrollContainer = false
+        view?.isScrollContainer = false
+//        inputPassword.stopNestedScroll()
+//        inputPassword.setHorizontallyScrolling(false)
+//        inputPassword.setSingleLine()
+//        inputPassword.isScrollContainer = false
+//        inputPassword.ellipsize = TextUtils.TruncateAt.END
+//        inputPassword.maxLines = 1
 
         inputUsername.readOnly = true
+        inputLayoutUsername.editText?.ellipsize = TextUtils.TruncateAt.END
+        inputUsername.ellipsize = TextUtils.TruncateAt.END
+        inputUsername.setSingleLine()
+
 
         if (!item.hasUsername) {
             btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent, null))

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -157,7 +157,6 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         inputUsername.ellipsize = TextUtils.TruncateAt.END
         inputUsername.setSingleLine()
 
-
         if (!item.hasUsername) {
             btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent, null))
             inputUsername.isClickable = false

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -86,7 +86,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingTop="26dp"
-                android:paddingEnd="16dp"
+                android:paddingEnd="14dp"
                 android:paddingBottom="26dp"
                 tools:ignore="RtlSymmetry">
 
@@ -105,7 +105,7 @@
                         android:layout_height="wrap_content"
                         android:scrollbars="none"
                         android:paddingStart="16dp"
-                        android:paddingEnd="12dp"
+                        android:paddingEnd="42dp"
                         android:textColorHint="@color/black_60_percent"
                         android:contentDescription="@string/launch_hostname_content_description"
                         app:layout_constraintTop_toTopOf="parent"
@@ -115,7 +115,7 @@
 
                     <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/inputHostname"
-                            style="@style/EditTextStyle"
+                            android:theme="@style/EditTextStyle"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:hint="@string/hint_hostname"
@@ -127,7 +127,6 @@
                             android:clickable="true"
                             android:focusable="true"
                             android:colorControlActivated="@color/violet_70"
-                            app:backgroundTint="@color/gray_divider"
                             tools:ignore="Autofill"/>
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -146,6 +145,15 @@
                         app:layout_constraintTop_toTopOf="parent"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:srcCompat="@drawable/ic_launch"/>
+
+                <View
+                        android:layout_height="1dp"
+                        android:layout_width="match_parent"
+                        android:background="@color/gray_divider"
+                        android:layout_marginStart="18dp"
+                        android:layout_marginTop="2dp"
+                        android:layout_marginEnd="11dp"
+                        card_view:layout_constraintTop_toBottomOf="@id/btnHostnameLaunch" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -161,7 +169,8 @@
                         android:layout_height="wrap_content"
                         android:layout_marginTop="16dp"
                         android:paddingStart="16dp"
-                        android:paddingEnd="12dp"
+                        android:paddingEnd="42dp"
+                        android:layout_weight="1"
                         android:textColorHint="@color/black_60_percent"
                         app:layout_constraintTop_toTopOf="parent"
                         app:layout_constraintBottom_toBottomOf="parent"
@@ -179,7 +188,6 @@
                             android:lines="1"
                             android:ellipsize="end"
                             android:colorControlActivated="@color/violet_70"
-                            app:backgroundTint="@color/gray_divider"
                             app:layout_constraintEnd_toEndOf="@+id/inputLayoutUsername"
                             app:layout_constraintTop_toTopOf="@+id/inputLayoutUsername"
                             tools:ignore="Autofill"/>
@@ -198,6 +206,15 @@
                         app:layout_constraintRight_toRightOf="@+id/inputLayoutUsername"
                         app:layout_constraintTop_toTopOf="@+id/inputLayoutUsername"
                         app:srcCompat="@drawable/ic_copy"/>
+
+                <View
+                        android:layout_height="1dp"
+                        android:layout_width="match_parent"
+                        android:background="@color/gray_divider"
+                        android:layout_marginStart="18dp"
+                        android:layout_marginTop="3dp"
+                        android:layout_marginEnd="11dp"
+                        card_view:layout_constraintTop_toBottomOf="@id/btnUsernameCopy" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -205,15 +222,15 @@
                     android:orientation="horizontal"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginEnd="16dp"
-                    android:layout_marginStart="16dp"
+                    android:layout_marginEnd="12dp"
+                    android:layout_marginStart="12dp"
                     app:layout_constraintTop_toBottomOf="@id/username"
                     card_view:layout_constraintStart_toStartOf="parent"
                     card_view:layout_constraintEnd_toEndOf="parent">
                 <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/inputLayoutPassword"
                         android:layout_width="0dp"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:layout_marginTop="5dp"
                         android:layout_weight="1"
                         android:textColorHint="@color/black_60_percent"
@@ -228,12 +245,10 @@
                                 android:id="@+id/inputPassword"
                                 style="@style/EditTextStyle"
                                 android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
+                                android:layout_height="match_parent"
                                 android:layout_gravity="center_vertical|start"
                                 android:hint="@string/hint_password"
-                                android:ellipsize="end"
-                                android:singleLine="true"
-                                android:scrollHorizontally="true"
+                                android:isScrollContainer="false"
                                 android:fontFamily="monospace"
                                 android:lineSpacingExtra="8sp"
                                 android:textSize="16sp"
@@ -268,8 +283,9 @@
                         android:paddingTop="8dp"
                         android:paddingBottom="8dp"
                         android:paddingStart="16dp"
+                        android:paddingEnd="4dp"
                         android:background="@null"
-                        tools:ignore="ContentDescription,RtlSymmetry"
+                        android:contentDescription="@string/copy_password_content_description"
                         app:layout_constraintTop_toTopOf="parent"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
@@ -279,7 +295,7 @@
                         android:layout_height="1dp"
                         android:layout_width="match_parent"
                         android:background="@color/gray_divider"
-                        android:layout_marginStart="8dp"
+                        android:layout_marginStart="6dp"
                         android:layout_marginTop="5dp"
                         card_view:layout_constraintTop_toBottomOf="@id/btnPasswordCopy" />
 

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -267,7 +267,6 @@
                         android:layout_marginEnd="16dp"
                         android:paddingBottom="8dp"
                         android:paddingTop="10dp"
-                        android:paddingEnd="16dp"
                         android:paddingStart="16dp"
                         android:background="@null"
                         android:contentDescription="@string/display_password_content_description"
@@ -298,7 +297,6 @@
                         android:layout_marginStart="6dp"
                         android:layout_marginTop="5dp"
                         card_view:layout_constraintTop_toBottomOf="@id/btnPasswordCopy" />
-
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_item_edit.xml
+++ b/app/src/main/res/layout/fragment_item_edit.xml
@@ -101,7 +101,7 @@
 
                 <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/inputLayoutName"
-                        android:layout_width="match_parent"
+                        android:layout_width="fill_parent"
                         android:layout_height="wrap_content"
                         android:paddingStart="16dp"
                         android:textColorHint="@color/black_60_percent"
@@ -113,7 +113,7 @@
 
                     <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/inputName"
-                            android:layout_width="match_parent"
+                            android:layout_width="fill_parent"
                             android:layout_height="wrap_content"
                             android:textColor="@color/gray_73_percent"
                             android:hint="@string/hint_entryname"
@@ -124,13 +124,13 @@
                             android:lineSpacingExtra="4sp"
                             android:inputType="textNoSuggestions"
                             android:singleLine="true"
+                            android:ellipsize="end"
                             android:clickable="false"
                             android:focusable="false"
                             app:backgroundTint="@color/gray_divider"
                             tools:ignore="Autofill"/>
                 </com.google.android.material.textfield.TextInputLayout>
             </androidx.constraintlayout.widget.ConstraintLayout>
-
 
             <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/entryHostname"

--- a/app/src/main/res/layout/fragment_item_edit.xml
+++ b/app/src/main/res/layout/fragment_item_edit.xml
@@ -131,7 +131,6 @@
                             android:maxLines="1"
                             android:clickable="false"
                             android:focusable="false"
-                            android:editable="false"
                             app:backgroundTint="@color/gray_divider"
                             tools:ignore="Autofill"/>
                 </com.google.android.material.textfield.TextInputLayout>
@@ -176,7 +175,6 @@
                             android:singleLine="true"
                             android:clickable="true"
                             android:focusable="true"
-                            android:editable="false"
                             android:textCursorDrawable="@android:color/transparent"
                             app:backgroundTint="@color/gray_divider"
                             tools:ignore="Autofill"/>

--- a/app/src/main/res/layout/fragment_item_edit.xml
+++ b/app/src/main/res/layout/fragment_item_edit.xml
@@ -274,6 +274,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginEnd="5dp"
+                        android:layout_marginBottom="8dp"
                         android:background="@null"
                         android:foregroundGravity="center_horizontal|center_vertical"
                         android:contentDescription="@string/display_password_content_description"

--- a/app/src/main/res/layout/fragment_item_edit.xml
+++ b/app/src/main/res/layout/fragment_item_edit.xml
@@ -79,7 +79,7 @@
             android:id="@+id/cardView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingBottom="20dp"
+            android:paddingBottom="26dp"
             android:paddingStart="16dp"
             android:paddingEnd="16dp"
             android:layout_gravity="center"
@@ -243,6 +243,7 @@
                         android:layout_height="wrap_content"
                         android:paddingStart="16dp"
                         android:paddingEnd="32dp"
+                        android:paddingBottom="4dp"
                         android:layout_weight="1"
                         android:textColorHint="@color/hint_edit_text"
                         android:colorControlActivated="@color/violet_70"
@@ -254,8 +255,7 @@
 
                     <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/inputPassword"
-                            android:paddingBottom="15dp"
-                            android:textSize="16sp"
+                            android:textSize="15sp"
                             android:textStyle="normal"
                             android:textColor="@color/black_87_percent"
                             android:lineSpacingExtra="8sp"
@@ -290,39 +290,8 @@
                         android:background="@color/gray_divider"
                         android:layout_marginStart="18dp"
                         android:layout_marginEnd="2dp"
-                        android:layout_marginTop="12dp"
+                        android:layout_marginTop="8dp"
                         card_view:layout_constraintTop_toBottomOf="@id/btnPasswordToggle" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    card_view:layout_constraintTop_toBottomOf="@+id/entryPassword">
-
-                <Button
-
-                        android:id="@+id/deleteEntryButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:gravity="center_horizontal|center_vertical"
-                        android:layout_marginEnd="16dp"
-                        android:paddingStart="5dp"
-                        android:paddingEnd="5dp"
-                        android:text="@string/delete_entry"
-                        android:textAllCaps="true"
-                        android:textSize="14sp"
-                        android:textAlignment="center"
-                        android:fontFamily="sans-serif-medium"
-                        android:textStyle="normal"
-                        android:textColor="@color/red"
-                        android:letterSpacing="0.09"
-                        android:lineSpacingExtra="2sp"
-                        android:shadowColor="@color/background_white"
-                        android:backgroundTint="@color/background_white"
-                        android:stateListAnimator="@null"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/fragment_item_edit.xml
+++ b/app/src/main/res/layout/fragment_item_edit.xml
@@ -80,6 +80,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingBottom="20dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
             android:layout_gravity="center"
             android:fitsSystemWindows="true"
             card_view:layout_constraintTop_toBottomOf="@id/toolbar">
@@ -90,6 +92,7 @@
                 android:layout_height="match_parent"
                 android:paddingTop="20dp"
                 android:paddingBottom="16dp"
+                android:paddingEnd="5dp"
                 tools:ignore="RtlSymmetry">
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -125,8 +128,10 @@
                             android:inputType="textNoSuggestions"
                             android:singleLine="true"
                             android:ellipsize="end"
+                            android:maxLines="1"
                             android:clickable="false"
                             android:focusable="false"
+                            android:editable="false"
                             app:backgroundTint="@color/gray_divider"
                             tools:ignore="Autofill"/>
                 </com.google.android.material.textfield.TextInputLayout>
@@ -155,7 +160,6 @@
 
                     <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/inputHostname"
-
                             android:textSize="16sp"
                             android:fontFamily="sans-serif"
                             android:textStyle="normal"
@@ -167,9 +171,12 @@
                             android:layout_height="wrap_content"
                             android:hint="@string/hint_hostname"
                             android:inputType="textNoSuggestions"
+                            android:ellipsize="end"
+                            android:maxLines="1"
                             android:singleLine="true"
                             android:clickable="true"
                             android:focusable="true"
+                            android:editable="false"
                             android:textCursorDrawable="@android:color/transparent"
                             app:backgroundTint="@color/gray_divider"
                             tools:ignore="Autofill"/>
@@ -200,7 +207,6 @@
 
                     <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/inputUsername"
-
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:hint="@string/hint_username"
@@ -212,6 +218,8 @@
                             android:lineSpacingExtra="8sp"
                             android:inputType="textNoSuggestions"
                             android:singleLine="true"
+                            android:ellipsize="end"
+                            android:maxLines="1"
                             android:clickable="true"
                             android:focusable="true"
                             app:backgroundTint="@color/gray_divider"
@@ -234,6 +242,8 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:paddingStart="16dp"
+                        android:paddingEnd="32dp"
+                        android:layout_weight="1"
                         android:textColorHint="@color/hint_edit_text"
                         android:colorControlActivated="@color/violet_70"
                         android:contentDescription="@string/entry_password_description"
@@ -257,7 +267,7 @@
                             android:singleLine="true"
                             android:clickable="true"
                             android:focusable="true"
-                            app:backgroundTint="@color/gray_divider"
+                            app:backgroundTint="@android:color/transparent"
                             tools:ignore="Autofill"/>
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -265,15 +275,23 @@
                         android:id="@+id/btnPasswordToggle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginEnd="16dp"
-                        android:layout_marginBottom="12dp"
-                        android:padding="10dp"
+                        android:layout_marginEnd="5dp"
                         android:background="@null"
+                        android:foregroundGravity="center_horizontal|center_vertical"
                         android:contentDescription="@string/display_password_content_description"
                         app:layout_constraintTop_toTopOf="@+id/inputLayoutPassword"
-                        card_view:layout_constraintEnd_toEndOf="@id/inputLayoutPassword"
                         app:layout_constraintBottom_toBottomOf="@+id/inputLayoutPassword"
+                        card_view:layout_constraintEnd_toEndOf="@id/inputLayoutPassword"
                         app:srcCompat="@drawable/ic_show"/>
+
+                <View
+                        android:layout_height="1dp"
+                        android:layout_width="match_parent"
+                        android:background="@color/gray_divider"
+                        android:layout_marginStart="18dp"
+                        android:layout_marginEnd="2dp"
+                        android:layout_marginTop="12dp"
+                        card_view:layout_constraintTop_toBottomOf="@id/btnPasswordToggle" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -282,22 +300,23 @@
                     card_view:layout_constraintTop_toBottomOf="@+id/entryPassword">
 
                 <Button
+
                         android:id="@+id/deleteEntryButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:gravity="center_horizontal|center_vertical"
-                        android:layout_marginEnd="30dp"
-                        android:paddingEnd="5dp"
+                        android:layout_marginEnd="16dp"
                         android:paddingStart="5dp"
+                        android:paddingEnd="5dp"
                         android:text="@string/delete_entry"
                         android:textAllCaps="true"
                         android:textSize="14sp"
+                        android:textAlignment="center"
                         android:fontFamily="sans-serif-medium"
                         android:textStyle="normal"
                         android:textColor="@color/red"
                         android:letterSpacing="0.09"
                         android:lineSpacingExtra="2sp"
-                        android:drawablePadding="12dp"
                         android:shadowColor="@color/background_white"
                         android:backgroundTint="@color/background_white"
                         android:stateListAnimator="@null"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -268,8 +268,6 @@
 <!--        (inklusive „https://“ und „www“).-->
 <!--    </string>-->
     <string name="entry_password_description">Passwort für diesen Eintrag.</string>
-    <!-- This is the text on the button in the edit view that allows you to delete the entry. -->
-    <string name="delete_entry">Eintrag löschen</string>
     <!-- This is the title text on the dialog when you attempt to close the edit view and changes have been made. -->
     <string name="discard_changes">Änderungen verwerfen?</string>
     <!-- This is the additional text when you attempt to close the edit view and changes have been made. -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -264,8 +264,6 @@
     <!-- This is a heading that appears above an entry name in context of a edit item view -->
     <string name="hint_entryname">Nombre</string>
     <string name="entry_password_description">Contraseña para esta entrada.</string>
-    <!-- This is the text on the button in the edit view that allows you to delete the entry. -->
-    <string name="delete_entry">Eliminar entrada</string>
     <!-- This is the title text on the dialog when you attempt to close the edit view and changes have been made. -->
     <string name="discard_changes">¿Descartar los cambios?</string>
     <!-- This is the additional text when you attempt to close the edit view and changes have been made. -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -263,8 +263,6 @@
     <!-- This is the hint in the edit entry view for formatting the entry hostname. -->
 <!--    <string name="hostname_entry_description">Assurez-vous que cela correspond au domaine exact du site web que vous recherchez (« https:// » et « www » inclus).</string>-->
     <string name="entry_password_description">Mot de passe pour cette entrée.</string>
-    <!-- This is the text on the button in the edit view that allows you to delete the entry. -->
-    <string name="delete_entry">Supprimer l’entrée</string>
     <!-- This is the title text on the dialog when you attempt to close the edit view and changes have been made. -->
     <string name="discard_changes">Abandonner les modifications ?</string>
     <!-- This is the additional text when you attempt to close the edit view and changes have been made. -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -271,8 +271,6 @@
     <!-- This is the hint in the edit entry view for formatting the entry hostname. -->
 <!--    <string name="hostname_entry_description">Assicurarsi che corrisponda esattamente al dominio del sito web a cui fa riferimento (inclusi “https://” e “www“).</string>-->
     <string name="entry_password_description">Password per questa voce.</string>
-    <!-- This is the text on the button in the edit view that allows you to delete the entry. -->
-    <string name="delete_entry">Elimina voce</string>
     <!-- This is the title text on the dialog when you attempt to close the edit view and changes have been made. -->
     <string name="discard_changes">Ignorare le modifiche?</string>
     <!-- This is the additional text when you attempt to close the edit view and changes have been made. -->

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -267,8 +267,6 @@
 <!--        (Bao gồm “https://” và “www”).-->
 <!--    </string>-->
     <string name="entry_password_description">Mật khẩu cho mục này.</string>
-    <!-- This is the text on the button in the edit view that allows you to delete the entry. -->
-    <string name="delete_entry">Xóa mục</string>
     <!-- This is the title text on the dialog when you attempt to close the edit view and changes have been made. -->
     <string name="discard_changes">Loại bỏ những thay đổi?</string>
     <!-- This is the additional text when you attempt to close the edit view and changes have been made. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -265,12 +265,11 @@
     <string name="edit">Edit</string>
     <!-- This is the hint in the edit entry view for the entry name. -->
     <string name="entry_name_description">The entry name</string>
-    <!-- This is a heading that appears above an entry name in context of a edit item view -->
+    <!-- This is a heading that appears above an entry name in context of an edit item view -->
     <string name="hint_entryname">Name</string>
 
+    <!-- This is the description for the entry password in context of an edit item view. -->
     <string name="entry_password_description">Password for this entry.</string>
-    <!-- This is the text on the button in the edit view that allows you to delete the entry. -->
-    <string name="delete_entry">Delete Entry</string>
     <!-- This is the title text on the dialog when you attempt to close the edit view and changes have been made. -->
     <string name="discard_changes">Discard changes?</string>
     <!-- This is the additional text when you attempt to close the edit view and changes have been made. -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -112,6 +112,10 @@
         <item name="android:textStyle">normal</item>
         <item name="android:textColor">@color/text_ink</item>
         <item name="android:letterSpacing">0.01</item>
+        <item name="android:scrollHorizontally">false</item>
+        <item name="android:isScrollContainer">false</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:singleLine">true</item>
         <item name="android:lineSpacingExtra">8sp</item>
         <item name="android:backgroundTint">@color/background_white</item>
         <item name="android:popupBackground">@android:color/transparent</item>

--- a/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
@@ -75,10 +75,6 @@ class EditItemPresenterTest {
         @StringRes var passwordError: Int? = null
         var _saveEnabled = true
 
-        val deleteClicksStub = PublishSubject.create<Unit>()
-        override val deleteClicks: Observable<Unit>
-            get() = deleteClicksStub
-
         val closeEntryClicksStub = PublishSubject.create<Unit>()
         override val closeEntryClicks: Observable<Unit>
             get() = closeEntryClicksStub
@@ -242,19 +238,6 @@ class EditItemPresenterTest {
             listOf(
                 DataStoreAction.UpdateItemDetail(fakeCredential),
                 RouteAction.ItemList
-            )
-        )
-    }
-
-    @Test
-    fun `tapping on delete button`() {
-        setUpTestSubject(fakeCredential.asOptional())
-
-        view.deleteClicksStub.onNext(Unit)
-
-        dispatcherObserver.assertValueSequence(
-            listOf(
-                DialogAction.DeleteConfirmationDialog(fakeCredential)
             )
         )
     }


### PR DESCRIPTION
Related to #928

## Testing and Review Notes

- [x] padding on all fields in item detail and edit so edittext doesn't overlap the show/hide/copy/launch buttons
- [x] align line lengths in item detail and edit views
- [x] align buttons in item detail and edit views
- [x] remove `DELETE ENTRY` button on edit view 

### Ellipsize
- [x] username on item list
- [ ] username on item detail
- [ ] username on edit
- [ ] password on item detial
- [ ] password on edit
- [ ] hostname on item detail
- [ ] hostname on edit

## Screenshots or Videos

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
