### PR TITLE
980: Register clicks from the launch button on item detail.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
@@ -37,6 +37,7 @@ interface ItemDetailView {
     val passwordFieldClicks: Observable<Unit>
     val togglePasswordClicks: Observable<Unit>
     val hostnameClicks: Observable<Unit>
+    val launchButtonClicks: Observable<Unit>
     val kebabMenuClicks: Observable<Unit>
     val editClicks: BehaviorRelay<Unit>
     val deleteClicks: BehaviorRelay<Unit>
@@ -118,6 +119,12 @@ class ItemDetailPresenter(
         }
 
         handleClicks(view.hostnameClicks) {
+            if (it.hostname.isNotEmpty()) {
+                dispatcher.dispatch(RouteAction.OpenWebsite(it.hostname))
+            }
+        }
+
+        handleClicks(view.launchButtonClicks) {
             if (it.hostname.isNotEmpty()) {
                 dispatcher.dispatch(RouteAction.OpenWebsite(it.hostname))
             }

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -84,6 +84,9 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
     override val hostnameClicks: Observable<Unit>
         get() = view!!.inputHostname.clicks()
 
+    override val launchButtonClicks: Observable<Unit>
+        get() = view!!.btnHostnameLaunch.clicks()
+
     override val kebabMenuClicks: Observable<Unit>
         get() = view!!.toolbar.kebabMenuButton.clicks()
 

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
@@ -90,6 +90,7 @@ class ItemDetailPresenterTest {
         override val passwordCopyClicks = PublishSubject.create<Unit>()
         override val togglePasswordClicks = PublishSubject.create<Unit>()
         override val hostnameClicks = PublishSubject.create<Unit>()
+        override val launchButtonClicks = PublishSubject.create<Unit>()
 
         override var isPasswordVisible: Boolean = false
 
@@ -236,6 +237,16 @@ class ItemDetailPresenterTest {
         setUpTestSubject(fakeCredential.asOptional())
 
         val clicks = view.hostnameClicks
+        clicks.onNext(Unit)
+
+        dispatcherObserver.assertLastValue(RouteAction.OpenWebsite(fakeCredential.hostname))
+    }
+
+    @Test
+    fun `opens a browser when tapping on the hostname launch button`() {
+        setUpTestSubject(fakeCredential.asOptional())
+
+        val clicks = view.launchButtonClicks
         clicks.onNext(Unit)
 
         dispatcherObserver.assertLastValue(RouteAction.OpenWebsite(fakeCredential.hostname))


### PR DESCRIPTION
Fixes #980

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
