### PR TITLE
Ensure discard changes dialog manages history properly

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
@@ -103,6 +103,7 @@ sealed class DialogAction(
             R.color.red
         ),
         listOf(
+            ItemList,
             ItemDetail(itemId)
         )
     )

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -105,7 +105,7 @@ class EditItemPresenter(
 
         view.closeEntryClicks
             .subscribe {
-                dispatcher.dispatch(DialogAction.DiscardChangesDialog(credentials!!.id))
+                dispatcher.dispatch(DialogAction.DiscardChangesDialog(itemId))
             }
             .addTo(compositeDisposable)
 

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -211,6 +211,7 @@
         <action
                 android:id="@+id/action_itemEdit_to_itemList"
                 app:destination="@id/fragment_item_list"
+                app:launchSingleTop="true"
                 app:popUpToInclusive="true"/>
         <action
                 android:id="@+id/action_itemEdit_to_itemDetail"


### PR DESCRIPTION
Fixes #983 .

This PR does not fix #897 but relies on the reconstructing the `ItemList` up to the `ItemDetail`.