### PR TITLE
Use extra fields to detect duplicates.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/extensions/ServerPassword+.kt
+++ b/app/src/main/java/mozilla/lockbox/extensions/ServerPassword+.kt
@@ -6,6 +6,7 @@
 
 package mozilla.lockbox.extensions
 
+import io.reactivex.Observable
 import mozilla.appservices.logins.ServerPassword
 import mozilla.lockbox.model.ItemDetailViewModel
 import mozilla.lockbox.model.ItemViewModel
@@ -26,4 +27,63 @@ private fun titleFromHostname(hostname: String): String {
             .replace(Regex("^http://"), "")
             .replace(Regex("^https://"), "")
             .replace(Regex("^www\\d*\\."), "")
+}
+
+fun Observable<List<ServerPassword>>.filter(
+    username: String? = null,
+    password: String? = null,
+    hostname: String? = null,
+    httpRealm: String? = null,
+    formSubmitURL: String? = null
+): Observable<List<ServerPassword>> =
+    this.map { items ->
+        items.filter(
+            username = username,
+            password = password,
+            hostname = hostname,
+            httpRealm = httpRealm,
+            formSubmitURL = formSubmitURL
+        )
+    }
+
+fun Collection<ServerPassword>.filter(
+    username: String? = null,
+    password: String? = null,
+    hostname: String? = null,
+    httpRealm: String? = null,
+    formSubmitURL: String? = null
+) =
+    this.filter {
+        it.matches(
+            username = username,
+            password = password,
+            hostname = hostname,
+            httpRealm = httpRealm,
+            formSubmitURL = formSubmitURL
+        )
+    }
+
+fun ServerPassword.matches(
+    username: String? = null,
+    password: String? = null,
+    hostname: String? = null,
+    httpRealm: String? = null,
+    formSubmitURL: String? = null
+): Boolean {
+    fun queryMatch(query: String?, candidate: String?) =
+        when (query) {
+            null -> true
+            "" -> true
+            candidate -> true
+            else -> false
+        }
+
+    return when {
+        queryMatch(username, this.username).not() -> false
+        queryMatch(hostname, this.hostname).not() -> false
+        queryMatch(httpRealm, this.httpRealm).not() -> false
+        queryMatch(password, this.password).not() -> false
+        queryMatch(formSubmitURL, this.formSubmitURL).not() -> false
+        else -> true
+    }
 }

--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -24,6 +24,7 @@ import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.action.SentryAction
 import mozilla.lockbox.extensions.filterByType
+import mozilla.lockbox.extensions.filter
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.log
 import mozilla.lockbox.model.SyncCredentials
@@ -188,14 +189,22 @@ open class DataStore(
         }
     }
 
-    // Returns a list of usernames that match the given hostname
-    open fun getUsernamesForHostname(hostname: String): Observable<Set<String?>> {
-        return list.map { items ->
-            items.filter { it.hostname == hostname }
-                .map { it.username }
-                .toSet()
+    // Returns a list of credentials that match the arguments given.
+    open fun filteredList(
+        username: String? = null,
+        password: String? = null,
+        hostname: String? = null,
+        httpRealm: String? = null,
+        formSubmitURL: String? = null
+    ): Observable<List<ServerPassword>> = list.map {
+            it.filter(
+                username = username,
+                password = password,
+                hostname = hostname,
+                httpRealm = httpRealm,
+                formSubmitURL = formSubmitURL
+            )
         }
-    }
 
     @VisibleForTesting(
         otherwise = VisibleForTesting.PRIVATE


### PR DESCRIPTION
Fixes #989. This PR makes the checking for duplicates use more fields to match credentials. 

It is modelled on [`findLogins` in Toolkit][1], introducing a `match` method which takes a set of properties as arguments. 

[1]: https://searchfox.org/mozilla-central/source/toolkit/components/passwordmgr/storage-mozStorage.js#719