### PR TITLE
929: Soft pan layout when clicking on fxa password field to open keyboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .externalNativeBuild
 /site
 .idea/assetWizardSettings.xml
+.idea/codeStyles/Project.xml
 .idea/gradle.xml
 .idea/caches
 .idea/navEditor.xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,9 +84,9 @@ configurations.all { config ->
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0-alpha09'
+    implementation 'com.google.android.material:material:1.2.0-alpha01'
     implementation "androidx.recyclerview:recyclerview:$recyclerview_version"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.0.0'

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -31,6 +31,7 @@ import mozilla.lockbox.support.isDebug
 @ExperimentalCoroutinesApi
 class FxALoginFragment : BackableFragment(), FxALoginView {
     private var errorHelper = NetworkErrorHelper()
+    private val inputMode = activity?.window?.attributes?.softInputMode
 
     override var webViewRedirect: ((url: Uri?) -> Boolean) = { _ -> false }
 
@@ -43,13 +44,17 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
         presenter = FxALoginPresenter(this)
 
         val view = inflater.inflate(R.layout.fragment_fxa_login, container, false)
-
         view.webView.settings.domStorageEnabled = true
         view.webView.settings.javaScriptEnabled = true
         CookieManager.getInstance().setAcceptCookie(true)
         activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
 
         return view
+    }
+
+    override fun onPause() {
+        super.onPause()
+        activity?.window?.setSoftInputMode(inputMode ?: WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -12,6 +12,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.webkit.CookieManager
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -40,10 +41,14 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
         savedInstanceState: Bundle?
     ): View? {
         presenter = FxALoginPresenter(this)
+
         val view = inflater.inflate(R.layout.fragment_fxa_login, container, false)
+
         view.webView.settings.domStorageEnabled = true
         view.webView.settings.javaScriptEnabled = true
         CookieManager.getInstance().setAcceptCookie(true)
+        activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+
         return view
     }
 


### PR DESCRIPTION
Fixes #929

## Testing and Review Notes


## Screenshots or Videos
![Screen Shot 2019-10-22 at 3 44 31 PM](https://user-images.githubusercontent.com/43795363/67340792-15ae2a80-f4e3-11e9-8374-c40de4b65269.png)

## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
