### PR TITLE
992: Hide soft keyboard on unlock.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
@@ -90,7 +90,8 @@ class ItemListFragment : Fragment(), ItemListView {
         sortList.add(Setting.ItemListSort.ALPHABETICALLY)
         sortList.add(Setting.ItemListSort.RECENTLY_USED)
         spinner = view.sortButton
-        sortItemsAdapter = SortItemAdapter(context!!, android.R.layout.simple_spinner_item, sortList)
+        sortItemsAdapter =
+            SortItemAdapter(context!!, android.R.layout.simple_spinner_item, sortList)
         spinner.adapter = sortItemsAdapter
         spinner.setPopupBackgroundResource(R.drawable.sort_menu_bg)
 
@@ -103,7 +104,12 @@ class ItemListFragment : Fragment(), ItemListView {
             override fun onNothingSelected(parent: AdapterView<*>?) {
             }
 
-            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+            override fun onItemSelected(
+                parent: AdapterView<*>?,
+                view: View?,
+                position: Int,
+                id: Long
+            ) {
                 if (userSelection) {
                     sortItemsAdapter.setSelection(position)
                     _sortItemSelection.onNext(sortMenuOptions[position])
@@ -181,8 +187,10 @@ class ItemListFragment : Fragment(), ItemListView {
         val header = view!!.navView.getHeaderView(0)
         val appName = getString(R.string.app_name)
         header.menuHeader.profileImage.contentDescription = getString(R.string.app_logo, appName)
-        header.menuHeader.displayName.text = profile.displayEmailName ?: resources.getString(R.string.firefox_account)
-        header.menuHeader.accountName.text = profile.accountName ?: resources.getString(R.string.app_name)
+        header.menuHeader.displayName.text =
+            profile.displayEmailName ?: resources.getString(R.string.firefox_account)
+        header.menuHeader.accountName.text =
+            profile.accountName ?: resources.getString(R.string.app_name)
 
         var avatarUrl = profile.avatarFromURL
         if (avatarUrl.isNullOrEmpty() || avatarUrl == resources.getString(R.string.default_avatar_url)) {
@@ -225,7 +233,10 @@ class ItemListFragment : Fragment(), ItemListView {
         if (!networkErrorVisibility) {
             errorHelper.showNetworkError(view!!)
         } else {
-            errorHelper.hideNetworkError(parent = view!!, child = view!!.refreshContainer.entriesView)
+            errorHelper.hideNetworkError(
+                parent = view!!,
+                child = view!!.refreshContainer.entriesView
+            )
         }
     }
 

--- a/app/src/main/java/mozilla/lockbox/view/LockedFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/LockedFragment.kt
@@ -6,11 +6,13 @@
 
 package mozilla.lockbox.view
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import com.jakewharton.rxbinding2.view.clicks
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
@@ -32,11 +34,21 @@ class LockedFragment : Fragment(), LockedView {
         return inflater.inflate(R.layout.fragment_locked, container, false)
     }
 
+    override fun onPause() {
+        super.onPause()
+        closeKeyboard()
+    }
+
     override val unlockButtonTaps: Observable<Unit>
         get() = view!!.unlockButton.clicks()
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         _onActivityResult.onNext(Pair(requestCode, resultCode))
+    }
+
+    private fun closeKeyboard() {
+        val imm = context?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view!!.windowToken, 0)
     }
 }


### PR DESCRIPTION
Fixes #992

## Testing and Review Notes
Hiding the keyboard on `onPause()` for the `LockedFragment`. There's a little bit of a "flash" of the splash screen in between unlocking and the item list. Not sure if we should open a issue to fix that, or ...?

## Screenshots or Videos
<img width="379" alt="autofill_capture_duolingo" src="https://user-images.githubusercontent.com/43795363/67420687-f5827800-f583-11e9-9329-1099ab940836.gif">


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)

