### PR TITLE
984: Remove color state change on hostname when clicking outside of the card view

### DIFF
--- a/app/src/main/res/layout/fragment_item_edit.xml
+++ b/app/src/main/res/layout/fragment_item_edit.xml
@@ -18,9 +18,6 @@
         android:fitsSystemWindows="true"
         android:windowActionBarOverlay="true"
         android:importantForAutofill="noExcludeDescendants"
-        android:clickable="true"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
         tools:ignore="UnusedAttribute"
         style="@style/EditItemDetail">
 
@@ -150,7 +147,9 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:paddingStart="16dp"
-                        android:textColorHint="@color/hint_edit_text"
+                        android:colorControlHighlight="@color/black_60_percent"
+                        android:colorControlActivated="@color/black_60_percent"
+                        android:textColorHint="@color/black_60_percent"
                         android:contentDescription="@string/web_address_description"
                         app:layout_constraintTop_toTopOf="parent"
                         card_view:layout_constraintStart_toStartOf="parent"
@@ -163,7 +162,7 @@
                             android:fontFamily="sans-serif"
                             android:textStyle="normal"
                             android:textColor="@color/gray_73_percent"
-                            android:textColorHint="@color/hint_edit_text"
+                            android:textColorHint="@color/black_60_percent"
                             android:letterSpacing="0.01"
                             android:lineSpacingExtra="8sp"
                             android:layout_width="match_parent"
@@ -173,8 +172,8 @@
                             android:ellipsize="end"
                             android:maxLines="1"
                             android:singleLine="true"
-                            android:clickable="true"
-                            android:focusable="true"
+                            android:clickable="false"
+                            android:focusable="false"
                             android:textCursorDrawable="@android:color/transparent"
                             app:backgroundTint="@color/gray_divider"
                             tools:ignore="Autofill"/>
@@ -289,7 +288,7 @@
                         android:background="@color/gray_divider"
                         android:layout_marginStart="18dp"
                         android:layout_marginEnd="2dp"
-                        android:layout_marginTop="8dp"
+                        android:layout_marginTop="9dp"
                         card_view:layout_constraintTop_toBottomOf="@id/btnPasswordToggle" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -57,10 +57,7 @@
         <item name="android:popupBackground">@android:color/transparent</item>
         <item name="android:background">@android:color/transparent</item>
         <item name="android:textColorHint">@color/black_60_percent</item>
-        <item name="android:colorControlActivated">@color/violet_70</item>
         <item name="android:colorControlNormal">@color/dark_grey</item>
-        <item name="android:colorControlHighlight">@color/violet_70</item>
-        <item name="colorAccent">@color/violet_70</item>
         <item name="errorTextAppearance">@style/ErrorText</item>
     </style>
 


### PR DESCRIPTION
Fixes #984

## Testing and Review Notes


## Screenshots or Videos
![edit_hostname_clicks](https://user-images.githubusercontent.com/43795363/67610558-7ab68a00-f748-11e9-8984-01d3c410dae3.gif)

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
