### PR TITLE
1048: Update link in settings to point to Sumo privacy article

### DIFF
--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -42,7 +42,7 @@ object Constant {
     }
 
     object Privacy {
-        const val uri = "https://lockwise.firefox.com/privacy.html"
+        const val uri = "https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy"
     }
 
     object SendFeedback {


### PR DESCRIPTION
Fixes #1048 

## Testing and Review Notes
**Old link (broken):** https://lockwise.firefox.com/privacy.html
**New link:** https://support.mozilla.org/en-US/kb/firefox-lockwise-and-privacy

## Screenshots or Videos

<img width="200" alt="image" src="https://user-images.githubusercontent.com/43795363/68428718-50b28e00-0172-11ea-8953-82a7a3c94b64.png">   <img width="200" alt="image" src="https://user-images.githubusercontent.com/43795363/68428567-0cbf8900-0172-11ea-8a47-e0df789686a9.png">


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
