### PR TITLE
Revert "1035 - Handles and context menus have solid backgrounds instead of transparent"

### DIFF
--- a/app/src/main/res/layout/fragment_account_setting.xml
+++ b/app/src/main/res/layout/fragment_account_setting.xml
@@ -5,13 +5,12 @@
   ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 <LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:theme="@style/AccountSettings"
-    tools:context=".view.AccountSettingFragment" >
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".view.AccountSettingFragment"
+        android:orientation="vertical">
 
     <include layout="@layout/include_backable"/>
 

--- a/app/src/main/res/layout/fragment_filter.xml
+++ b/app/src/main/res/layout/fragment_filter.xml
@@ -10,7 +10,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:theme="@style/Filter"
+    android:backgroundTint="@color/background_grey"
     android:importantForAutofill="noExcludeDescendants"
     tools:context=".view.FilterFragment"
     tools:ignore="UnusedAttribute">

--- a/app/src/main/res/layout/fragment_item_list.xml
+++ b/app/src/main/res/layout/fragment_item_list.xml
@@ -18,8 +18,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fitsSystemWindows="false"
-        android:orientation="vertical"
-        android:background="@color/background_white">
+        android:orientation="vertical">
 
         <androidx.appcompat.widget.Toolbar
                 android:id="@+id/navToolbar"

--- a/app/src/main/res/layout/fragment_onboarding_confirmation.xml
+++ b/app/src/main/res/layout/fragment_onboarding_confirmation.xml
@@ -9,7 +9,7 @@
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:theme="@style/OnboardingConfirmation"
+        android:theme="@style/AppTheme"
         android:id="@+id/fragment_onboarding_confirmation">
 
     <TextView

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -11,8 +11,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:theme="@style/AppSettings"
-    tools:context=".view.SettingFragment" >
+    android:theme="@style/AppTheme"
+    tools:context=".view.SettingFragment">
 
     <include layout="@layout/include_backable"/>
 

--- a/app/src/main/res/layout/include_backable_filter.xml
+++ b/app/src/main/res/layout/include_backable_filter.xml
@@ -4,14 +4,12 @@
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
-<androidx.appcompat.widget.Toolbar
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
-    android:theme="@style/BackableToolBar" >
-
+    android:theme="@style/BackableToolBar">
     <LinearLayout android:orientation="horizontal"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -28,8 +26,7 @@
             android:textColorHint="@color/white_60_percent"
             android:textCursorDrawable="@null"
             android:inputType="textAutoComplete"
-            tools:ignore="Autofill"
-            android:theme="@style/NoBackgroundTheme"/>
+            tools:ignore="Autofill" />
 
         <ImageButton
             android:id="@+id/cancelButton"

--- a/app/src/main/res/layout/list_cell_item.xml
+++ b/app/src/main/res/layout/list_cell_item.xml
@@ -10,7 +10,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="64dp"
-    android:theme="@style/ListCellItem"
     xmlns:tools="http://schemas.android.com/tools">
 
     <TextView

--- a/app/src/main/res/layout/nav_header.xml
+++ b/app/src/main/res/layout/nav_header.xml
@@ -11,7 +11,8 @@
     android:orientation="vertical"
     android:paddingStart="16dp"
     android:paddingEnd="16dp"
-    android:theme="@style/NavHeader"
+    android:theme="@style/AppTheme"
+    android:backgroundTint="@color/color_primary_dark"
     android:id="@+id/menuHeader"
     tools:ignore="UseCompoundDrawables">
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,18 +7,18 @@
 <resources>
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/color_primary</item>
         <item name="colorPrimaryDark">@color/color_primary_dark</item>
         <item name="android:textColor">@color/text_white</item>
         <item name="android:windowTranslucentStatus">false</item>
-        <item name="android:windowBackground">@color/background_white</item>
+        <item name="android:windowBackground">@null</item>
         <item name="android:colorControlActivated">@color/switch_activated</item>
-        <item name="android:background">@android:color/transparent</item>
+        <item name="android:background">@color/background_white</item>
         <item name="actionMenuTextAppearance">@style/NavDrawerStyle</item>
         <item name="android:actionMenuTextAppearance">@style/NavDrawerStyle</item>
         <item name="actionMenuTextColor">@style/NavDrawerStyle</item>
         <item name="android:titleTextAppearance">@style/NavDrawerStyle</item>
-        <item name="android:colorAccent">@color/violet_70</item>
         <item name="popupMenuStyle">@style/PopupMenu</item>
     </style>
 
@@ -51,15 +51,7 @@
 
     <style name="BackableToolBar" parent="ToolBar">
         <item name="android:background">@color/color_primary</item>
-        <item name="android:colorControlActivated">@color/violet_70</item>
-        <item name="android:textColor">@color/violet_70</item>
-        <item name="android:colorAccent">@color/violet_70</item>
-        <item name="android:editTextColor">@color/violet_70</item>
-        <item name="colorPrimary">@color/color_primary</item>
-        <item name="colorPrimaryDark">@color/color_primary_dark</item>
-        <item name="android:colorControlNormal">@color/violet_70</item>
     </style>
-
 
     <style name="EditItemDetail" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:popupBackground">@android:color/transparent</item>
@@ -95,7 +87,6 @@
         <item name="android:background">@color/color_primary</item>
         <item name="android:popupBackground">@android:color/transparent</item>
     </style>
-
     <style name="TextAppearance">
         <item name="android:letterSpacing">0.02</item>
         <item name="android:fontFamily">sans-serif</item>
@@ -103,18 +94,15 @@
         <item name="android:lineSpacingExtra">6sp</item>
         <item name="android:popupBackground">@android:color/transparent</item>
     </style>
-
     <style name="TextAppearanceSortMenuItem" parent="@style/TextAppearance">
         <item name="android:textColor">@color/black_87_percent</item>
     </style>
-
     <style name="ToolbarButton">
         <item name="android:tint">@android:color/white</item>
         <item name="android:background">@null</item>
         <item name="android:textColorPrimary">@android:color/white</item>
         <item name="android:textColorSecondary">@android:color/white</item>
     </style>
-
     <style name="EditTextStyle" parent="@android:style/Widget.EditText">
         <item name="android:textSize">16sp</item>
         <item name="android:fontFamily">sans-serif</item>
@@ -138,50 +126,11 @@
         <item name="android:backgroundTint">@color/background_white</item>
         <item name="android:popupBackground">@android:color/transparent</item>
     </style>
-
     <style name="WelcomeScreen" parent="AppTheme">
         <item name="android:background">@color/color_primary</item>
         <item name="android:windowBackground">@color/color_primary</item>
         <item name="android:colorBackground">@color/color_primary</item>
-        <item name="android:colorControlActivated">@color/violet_70</item>
     </style>
-
-    <style name="AccountSettings" parent="AppTheme">
-        <item name="android:background">@color/background_white</item>
-        <item name="android:colorControlActivated">@color/violet_70</item>
-    </style>
-
-    <style name="AppSettings" parent="AppTheme">
-        <item name="android:background">@color/background_white</item>
-        <item name="android:colorControlActivated">@color/violet_70</item>
-    </style>
-
-    <style name="NavHeader" parent="AppTheme">
-        <item name="android:background">@color/color_primary_dark</item>
-        <item name="android:colorControlActivated">@color/violet_70</item>
-    </style>
-
-    <style name="ListCellItem" parent="AppTheme">
-        <item name="android:background">@color/background_white</item>
-        <item name="android:colorControlActivated">@color/violet_70</item>
-    </style>
-
-    <style name="Filter" parent="AppTheme">
-        <item name="android:background">@color/background_grey</item>
-        <item name="android:colorControlActivated">@color/violet_70</item>
-        <item name="android:textColor">@color/violet_70</item>
-        <item name="android:colorAccent">@color/violet_70</item>
-        <item name="android:editTextColor">@color/violet_70</item>
-        <item name="colorPrimary">@color/color_primary</item>
-        <item name="colorPrimaryDark">@color/color_primary_dark</item>
-        <item name="android:colorControlNormal">@color/violet_70</item>
-    </style>
-
-    <style name="OnboardingConfirmation" parent="AppTheme">
-        <item name="android:background">@color/background_white</item>
-        <item name="android:colorControlActivated">@color/violet_70</item>
-    </style>
-
     <style name="AlertDialogStyle" parent="Theme.AppCompat.Light.Dialog">
         <item name="android:windowBackground">@drawable/rounded_corner_bg_white</item>
         <item name="android:textColorPrimary">@color/text_ink</item>


### PR DESCRIPTION
Reverts mozilla-lockwise/lockwise-android#1036

`Primary` builds are passing, but `Deploy` builds are failing on bitrise: 

```
Failed to fetch variants, error: FAILURE: Build failed with an exception.
* Where:
Build file '/bitrise/src/app/build.gradle' line: 24
* What went wrong:
A problem occurred evaluating project ':app'.
> Could not get unknown property 'ᔢ' for DefaultConfig_Decorated{name=main, dimension=null, minSdkVersion=DefaultApiVersion{mApiLevel=24, mCodename='null'}, targetSdkVersion=DefaultApiVersion{mApiLevel=28, mCodename='null'}, renderscriptTargetApi=null, renderscriptSupportModeEnabled=null, renderscriptSupportModeBlasEnabled=null, renderscriptNdkModeEnabled=null, versionCode=null, versionName=null, applicationId=mozilla.lockbox, testApplicationId=null, testInstrumentationRunner=null, testInstrumentationRunnerArguments={}, testHandleProfiling=null, testFunctionalTest=null, signingConfig=null, resConfig=null, mBuildConfigFields={}, mResValues={}, mProguardFiles=[], mConsumerProguardFiles=[], mManifestPlaceholders={}, mWearAppUnbundled=null} of type com.android.build.gradle.internal.dsl.DefaultConfig.
```