### PR TITLE
Add discard-changes dialog when back is pressed when editing a credential.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
@@ -103,8 +103,7 @@ sealed class DialogAction(
             R.color.red
         ),
         listOf(
-            ItemList,
-            ItemDetail(itemId)
+            ItemDetailAction.DiscardChanges(itemId)
         )
     )
 }

--- a/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
@@ -103,7 +103,7 @@ sealed class DialogAction(
             R.color.red
         ),
         listOf(
-            ItemDetailAction.DiscardChanges(itemId)
+            ItemDetailAction.EndEditing(itemId)
         )
     )
 }

--- a/app/src/main/java/mozilla/lockbox/action/ItemDetailAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/ItemDetailAction.kt
@@ -6,10 +6,16 @@
 
 package mozilla.lockbox.action
 
+import mozilla.appservices.logins.ServerPassword
+
 sealed class ItemDetailAction(
     override val eventMethod: TelemetryEventMethod,
     override val eventObject: TelemetryEventObject
 ) : TelemetryAction {
     data class SetPasswordVisibility(val visible: Boolean) :
         ItemDetailAction(TelemetryEventMethod.tap, TelemetryEventObject.reveal_password)
+    data class SaveChanges(val item: ServerPassword) :
+        ItemDetailAction(TelemetryEventMethod.tap, TelemetryEventObject.update_credential)
+    data class DiscardChanges(val itemId: String) :
+        ItemDetailAction(TelemetryEventMethod.tap, TelemetryEventObject.back)
 }

--- a/app/src/main/java/mozilla/lockbox/action/ItemDetailAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/ItemDetailAction.kt
@@ -16,6 +16,6 @@ sealed class ItemDetailAction(
         ItemDetailAction(TelemetryEventMethod.tap, TelemetryEventObject.reveal_password)
     data class SaveChanges(val item: ServerPassword) :
         ItemDetailAction(TelemetryEventMethod.tap, TelemetryEventObject.update_credential)
-    data class DiscardChanges(val itemId: String) :
+    data class EndEditing(val itemId: String) :
         ItemDetailAction(TelemetryEventMethod.tap, TelemetryEventObject.back)
 }

--- a/app/src/main/java/mozilla/lockbox/flux/Presenter.kt
+++ b/app/src/main/java/mozilla/lockbox/flux/Presenter.kt
@@ -12,6 +12,7 @@ import io.reactivex.disposables.CompositeDisposable
 abstract class Presenter {
     val compositeDisposable: CompositeDisposable = CompositeDisposable()
 
+    @CallSuper
     open fun onViewReady() {
         // NOOP
     }
@@ -30,4 +31,17 @@ abstract class Presenter {
     open fun onPause() {
         // NOOP
     }
+
+    @CallSuper
+    fun onStop() {
+        // NOOP
+    }
+
+    /**
+     * Called by the fragment when the back button is pressed.
+     *
+     * @return `true` if the back button event has been handled by the presenter.
+     * By default, returns false, in which case Android handles the event.
+     */
+    open fun onBackPressed(): Boolean = false
 }

--- a/app/src/main/java/mozilla/lockbox/flux/Presenter.kt
+++ b/app/src/main/java/mozilla/lockbox/flux/Presenter.kt
@@ -12,7 +12,6 @@ import io.reactivex.disposables.CompositeDisposable
 abstract class Presenter {
     val compositeDisposable: CompositeDisposable = CompositeDisposable()
 
-    @CallSuper
     open fun onViewReady() {
         // NOOP
     }

--- a/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
@@ -37,6 +37,7 @@ class AppRoutePresenter(
 ) : RoutePresenter(activity, dispatcher, routeStore) {
 
     override fun onViewReady() {
+        super.onViewReady()
         navController = Navigation.findNavController(activity, R.id.fragment_nav_host)
     }
 

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -30,6 +30,7 @@ import mozilla.lockbox.flux.Presenter
 import mozilla.lockbox.log
 import mozilla.lockbox.store.RouteStore
 import mozilla.lockbox.view.DialogFragment
+import mozilla.lockbox.view.Fragment as SpecializedFragment
 
 @ExperimentalCoroutinesApi
 abstract class RoutePresenter(
@@ -59,6 +60,12 @@ abstract class RoutePresenter(
         override fun handleOnBackPressed() {
             dispatcher.dispatch(RouteAction.InternalBack)
         }
+    }
+
+    override fun onBackPressed(): Boolean {
+        dispatcher.dispatch(RouteAction.InternalBack)
+        val fragment = currentFragment as? SpecializedFragment
+        return fragment?.onBackPressed() ?: false
     }
 
     private val onBackPressedDispatcher = activity.onBackPressedDispatcher

--- a/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
@@ -10,6 +10,8 @@ import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
 import io.reactivex.subjects.BehaviorSubject
+import mozilla.appservices.logins.ServerPassword
+import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.ItemDetailAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.extensions.filterByType
@@ -27,6 +29,9 @@ class ItemDetailStore(
     internal val _passwordVisible = BehaviorSubject.createDefault(false)
     val isPasswordVisible: Observable<Boolean> = _passwordVisible
 
+    internal val _isEditing = BehaviorSubject.createDefault(false)
+    val isEditing: Observable<Boolean> = _isEditing
+
     init {
         dispatcher.register
             .filterByType(RouteAction::class.java)
@@ -34,7 +39,7 @@ class ItemDetailStore(
                 when (action) {
                     is RouteAction.ItemDetail -> _passwordVisible.onNext(false)
                     is RouteAction.ItemList -> _passwordVisible.onNext(false)
-                    is RouteAction.EditItemDetail -> _passwordVisible.onNext(false)
+                    is RouteAction.EditItemDetail -> startEditing()
                 }
             }
             .addTo(compositeDisposable)
@@ -44,8 +49,24 @@ class ItemDetailStore(
             .subscribe { action ->
                 when (action) {
                     is ItemDetailAction.SetPasswordVisibility -> _passwordVisible.onNext(action.visible)
+                    is ItemDetailAction.SaveChanges -> saveItem(action.item)
+                    is ItemDetailAction.DiscardChanges -> stopEditing()
                 }
             }
             .addTo(compositeDisposable)
+    }
+
+    private fun startEditing() {
+        _passwordVisible.onNext(false)
+        _isEditing.onNext(true)
+    }
+
+    private fun saveItem(item: ServerPassword) {
+        dispatcher.dispatch(DataStoreAction.UpdateItemDetail(item))
+        stopEditing()
+    }
+
+    private fun stopEditing() {
+        _isEditing.onNext(false)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
@@ -50,7 +50,7 @@ class ItemDetailStore(
                 when (action) {
                     is ItemDetailAction.SetPasswordVisibility -> _passwordVisible.onNext(action.visible)
                     is ItemDetailAction.SaveChanges -> saveItem(action.item)
-                    is ItemDetailAction.DiscardChanges -> stopEditing()
+                    is ItemDetailAction.EndEditing -> stopEditing()
                 }
             }
             .addTo(compositeDisposable)

--- a/app/src/main/java/mozilla/lockbox/view/AutofillRootActivity.kt
+++ b/app/src/main/java/mozilla/lockbox/view/AutofillRootActivity.kt
@@ -27,8 +27,19 @@ class AutofillRootActivity : AppCompatActivity() {
         presenter.onViewReady()
     }
 
+    override fun onStop() {
+        super.onStop()
+        presenter.onStop()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         presenter.onDestroy()
+    }
+
+    override fun onBackPressed() {
+        if (!presenter.onBackPressed()) {
+            super.onBackPressed()
+        }
     }
 }

--- a/app/src/main/java/mozilla/lockbox/view/Fragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/Fragment.kt
@@ -64,4 +64,12 @@ open class Fragment : AndroidFragment() {
             return null
         }
     }
+
+    /**
+     * Called if the back button is pressed.
+     *
+     * @return `true` if the back button event has been handled. By default, returns false, in which
+     * case Android handles the event.
+     */
+    fun onBackPressed(): Boolean = presenter.onBackPressed()
 }

--- a/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
+++ b/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
@@ -40,4 +40,15 @@ class RootActivity : AppCompatActivity() {
         super.onResume()
         presenter.onResume()
     }
+
+    override fun onStop() {
+        super.onStop()
+        presenter.onStop()
+    }
+
+    override fun onBackPressed() {
+        if (!presenter.onBackPressed()) {
+            super.onBackPressed()
+        }
+    }
 }

--- a/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
@@ -12,14 +12,15 @@ import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.appservices.logins.ServerPassword
-import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.DialogAction
+import mozilla.lockbox.action.ItemDetailAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.log
 import mozilla.lockbox.model.ItemDetailViewModel
 import mozilla.lockbox.store.DataStore
+import mozilla.lockbox.store.ItemDetailStore
 import mozilla.lockbox.support.Optional
 import mozilla.lockbox.support.asOptional
 import org.junit.Assert.assertEquals
@@ -104,6 +105,10 @@ class EditItemPresenterTest {
     private val getStub = PublishSubject.create<Optional<ServerPassword>>()
     private val listStub = PublishSubject.create<List<ServerPassword>>()
 
+    val itemDetailStore = PowerMockito.mock(ItemDetailStore::class.java)!!
+    private val isPasswordVisibleStub = PublishSubject.create<Boolean>()
+    private val isEditingStub = PublishSubject.create<Boolean>()
+
     val dispatcher = Dispatcher()
     val dispatcherObserver = TestObserver.create<Action>()!!
 
@@ -156,10 +161,15 @@ class EditItemPresenterTest {
         dispatcher.register.subscribe(dispatcherObserver)
         Mockito.`when`(dataStore.get(ArgumentMatchers.anyString())).thenReturn(getStub)
         Mockito.`when`(dataStore.list).thenReturn(listStub)
+
+        Mockito.`when`(itemDetailStore.isPasswordVisible).thenReturn(isPasswordVisibleStub)
+        Mockito.`when`(itemDetailStore.isEditing).thenReturn(isEditingStub)
+
+        isEditingStub.onNext(true)
     }
 
     private fun setUpTestSubject(item: ServerPassword?) {
-        subject = EditItemPresenter(view, item?.id, dispatcher, dataStore)
+        subject = EditItemPresenter(view, item?.id, dispatcher, dataStore, itemDetailStore)
         subject.onViewReady()
 
         getStub.onNext(item.asOptional())
@@ -224,7 +234,7 @@ class EditItemPresenterTest {
 
         dispatcherObserver.assertValueSequence(
             listOf(
-                RouteAction.ItemDetail(fakeCredential.id)
+                ItemDetailAction.DiscardChanges(fakeCredential.id)
             )
         )
     }
@@ -251,8 +261,20 @@ class EditItemPresenterTest {
 
         dispatcherObserver.assertValueSequence(
             listOf(
-                DataStoreAction.UpdateItemDetail(fakeCredential),
-                RouteAction.ItemList
+                ItemDetailAction.SaveChanges(fakeCredential)
+            )
+        )
+    }
+
+    @Test
+    fun `stopping editing sends you back to the item detail`() {
+        setUpTestSubject(fakeCredential)
+        isEditingStub.onNext(false)
+
+        dispatcherObserver.assertValueSequence(
+            listOf(
+                RouteAction.ItemList,
+                RouteAction.ItemDetail(fakeCredential.id)
             )
         )
     }

--- a/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
@@ -217,9 +217,23 @@ class EditItemPresenterTest {
     }
 
     @Test
-    fun `tapping on close button`() {
+    fun `tapping on close button with no change`() {
         setUpTestSubject(fakeCredential)
 
+        view.closeEntryClicksStub.onNext(Unit)
+
+        dispatcherObserver.assertValueSequence(
+            listOf(
+                RouteAction.ItemDetail(fakeCredential.id)
+            )
+        )
+    }
+
+    @Test
+    fun `tapping on close button with change`() {
+        setUpTestSubject(fakeCredential)
+
+        view.usernameClicksStub.onNext("all-change")
         view.closeEntryClicksStub.onNext(Unit)
 
         dispatcherObserver.assertValueSequence(

--- a/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
@@ -234,7 +234,7 @@ class EditItemPresenterTest {
 
         dispatcherObserver.assertValueSequence(
             listOf(
-                ItemDetailAction.DiscardChanges(fakeCredential.id)
+                ItemDetailAction.EndEditing(fakeCredential.id)
             )
         )
     }
@@ -254,14 +254,28 @@ class EditItemPresenterTest {
     }
 
     @Test
-    fun `tapping on save button`() {
+    fun `tapping on save button with no changes`() {
         setUpTestSubject(fakeCredential)
 
         view.saveEntryClicksStub.onNext(Unit)
 
         dispatcherObserver.assertValueSequence(
             listOf(
-                ItemDetailAction.SaveChanges(fakeCredential)
+                ItemDetailAction.EndEditing(fakeCredential.id)
+            )
+        )
+    }
+
+    @Test
+    fun `tapping on save button`() {
+        setUpTestSubject(fakeCredential)
+
+        view.usernameClicksStub.onNext("all-change")
+        view.saveEntryClicksStub.onNext(Unit)
+
+        dispatcherObserver.assertValueSequence(
+            listOf(
+                ItemDetailAction.SaveChanges(fakeCredential.copy(username = "all-change"))
             )
         )
     }

--- a/app/src/test/java/mozilla/lockbox/store/ItemDetailStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/ItemDetailStoreTest.kt
@@ -78,7 +78,7 @@ class ItemDetailStoreTest : DisposingTest() {
         dispatcher.dispatch(RouteAction.EditItemDetail(itemId))
         observer.assertLastValue(true)
 
-        dispatcher.dispatch(ItemDetailAction.DiscardChanges(itemId))
+        dispatcher.dispatch(ItemDetailAction.EndEditing(itemId))
         observer.assertLastValue(false)
     }
 


### PR DESCRIPTION
Fixes #994.

This PR introduces: 

 * infrastructure in the Activity and RoutePresenter to allow the presenter to customize the effect of the back button.
 * check in edit item screen to see if any editing has occurred.
 * bolstering of the edit item store to show the discard-changes-dialog if and only if an edit has been made.