### PR TITLE
Release notes v3.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
         minSdkVersion 24
         //noinspection OldTargetApi
         targetSdkVersion 28
-        versionCode 5358
-        versionName "3.1.0"
+        versionCode 5522
+        versionName "3.2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         //noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.sentry:sentry-android-gradle-plugin:$sentry_version"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## 3.2.0 (Build 5522)
+
+Stability and UI cleanup.
+
+All changes since version 3.1.0:
+
+- Search bar text handles have violet background (#1035)
+- Reconcile l10n strings for translation #1020
+- Close keyboard when exiting feedback form (#1057)
+- Update ---feature.md (#1063)
+- The device back button doesn't have the same functionality with the X button in Edit Login Mode (994)
+- Remove "name" field from the edit view (#1010)
+- Whooops! Wrong URL displayed when accessing Learn More from Lockwise settings (#1048)
+
 ## 3.1.0 (Build 5356)
 
 Improve autofill detection and increase target SDK to 28.


### PR DESCRIPTION
# Release Notes

## 3.2.0 (Build 5522)

Stability and UI cleanup.

All changes since version 3.1.0:

- Search bar text handles have violet background (#1035)
- Reconcile l10n strings for translation #1020
- Close keyboard when exiting feedback form (#1057)
- Update ---feature.md (#1063)
- The device back button doesn't have the same functionality with the X button in Edit Login Mode (994)
- Remove "name" field from the edit view (#1010)
- Whooops! Wrong URL displayed when accessing Learn More from Lockwise settings (#1048)
