### PR TITLE
Bump the required Android Components version to 19.0.1

### DIFF
--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -281,6 +281,7 @@ open class AccountStore(
 
         fxa.beginOAuthFlowAsync(Constant.FxA.scopes)
             .asMaybe(coroutineContext)
+            .map { it.url }
             .subscribe((this.loginURL as Subject)::onNext, this::pushError)
             .addTo(compositeDisposable)
     }

--- a/app/src/main/java/mozilla/lockbox/store/TelemetryStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/TelemetryStore.kt
@@ -4,6 +4,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+// The 'service-telemetry' library is deprecated and will go away. Until the Glean
+// SDK is fully integrated with Lockwise for Android, keep the suppression on. See
+// bug 1597623.
+@file:Suppress("DEPRECATION")
+
 package mozilla.lockbox.store
 
 import android.content.Context

--- a/app/src/test/java/mozilla/lockbox/mocks/MockLoginsStorage.kt
+++ b/app/src/test/java/mozilla/lockbox/mocks/MockLoginsStorage.kt
@@ -76,6 +76,19 @@ open class MockLoginsStorage : LoginsStorage {
     override fun wipe() {}
 
     override fun wipeLocal() {}
+
+    override fun getByHostname(hostname: String): List<ServerPassword> {
+        return all.filter { hostname == it.hostname }
+    }
+
+    override fun getHandle(): Long {
+        throw UnsupportedOperationException()
+    }
+
+    override fun importLogins(logins: Array<ServerPassword>): Long {
+        all.addAll(logins)
+        return 0 // no errors
+    }
 }
 
 class MockDataStoreSupport : DataStoreSupport {

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@
 buildscript {
     ext.android_support_version = '28.0.0'
     ext.kotlin_version = '1.3.0'
-    ext.android_components_version = '9.0.0'
+    ext.android_components_version = '19.0.1'
     // Determined from
-    // https://github.com/mozilla-mobile/android-components/blob/v0.51.0/buildSrc/src/main/java/Dependencies.kt,
+    // https://github.com/mozilla-mobile/android-components/blob/v19.0.1/buildSrc/src/main/java/Dependencies.kt,
     // where the version in the URL is the tag corresponding to `android_components_version`.
     ext.mozilla_appservices_version = '0.42.0'
     ext.lifecycle_version = '1.1.1'


### PR DESCRIPTION
This is the first version that comes with a Rust implementation of the Glean SDK and is the suggested starting version for integrating with the Glean SDK.

~~**Currently failing**~~

```
e: E:\Mozilla\lockwise-android\app\src\main\java\mozilla\lockbox\store\AccountStore.kt: (284, 24): Type mismatch: inferred type is KFunction1<@ParameterName String, Unit> but Consumer<in AuthFlowUrl!>! was expected
e: E:\Mozilla\lockwise-android\app\src\main\java\mozilla\lockbox\store\AccountStore.kt: (284, 60): Type mismatch: inferred type is KFunction1<@ParameterName Throwable, Unit> but Consumer<in Throwable!>! was expected

```

Connected to #127 

## To Do

- [x] fix compilation errors
