### PR TITLE
991: UX cleanup part deux

### DIFF
--- a/app/src/main/java/mozilla/lockbox/model/SyncCredentials.kt
+++ b/app/src/main/java/mozilla/lockbox/model/SyncCredentials.kt
@@ -12,7 +12,7 @@ import mozilla.lockbox.support.DataStoreSupport
 import mozilla.lockbox.support.FixedDataStoreSupport
 import mozilla.lockbox.support.FxASyncDataStoreSupport
 
-private val emptyString = ""
+private const val emptyString = ""
 
 interface SyncCredentials {
     val isNew: Boolean

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -44,7 +44,7 @@ interface EditItemDetailView {
     fun displayUsernameError(@StringRes errorMessage: Int? = null)
     fun displayPasswordError(@StringRes errorMessage: Int? = null)
     fun setSaveEnabled(enabled: Boolean)
-    fun setTextSelectionOnPasswordToggle()
+    fun setTextSelectionToEndOfLine()
 }
 
 @ExperimentalCoroutinesApi
@@ -135,13 +135,13 @@ class EditItemPresenter(
                 dispatcher.dispatch(
                     ItemDetailAction.SetPasswordVisibility(view.isPasswordVisible.not())
                 )
-                view.setTextSelectionOnPasswordToggle()
+                view.setTextSelectionToEndOfLine()
             }
             .addTo(compositeDisposable)
 
         view.usernameFieldClicks
             .subscribe {
-                view.setTextSelectionOnPasswordToggle()
+                view.setTextSelectionToEndOfLine()
             }
             .addTo(compositeDisposable)
 

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -98,10 +98,10 @@ class EditItemPresenter(
         Observables.combineLatest(getItem, dataStore.list)
             .map { (item, list) ->
                 list.filter(
-                    hostname = item.hostname,
-                    httpRealm = item.httpRealm,
-                    formSubmitURL = item.formSubmitURL
-                )
+                        hostname = item.hostname,
+                        httpRealm = item.httpRealm,
+                        formSubmitURL = item.formSubmitURL
+                    )
                     .map { it.username }
                     .toSet()
                     .minus(item.username)
@@ -129,11 +129,8 @@ class EditItemPresenter(
             .addTo(compositeDisposable)
 
         view.togglePasswordClicks
-            .subscribe {
-                dispatcher.dispatch(
-                    ItemDetailAction.SetPasswordVisibility(view.isPasswordVisible.not())
-                )
-            }
+            .map { ItemDetailAction.SetPasswordVisibility(view.isPasswordVisible.not()) }
+            .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
 
         view.closeEntryClicks
@@ -183,7 +180,7 @@ class EditItemPresenter(
     }
 
     private fun checkDismissChanges(itemId: String) =
-    // When something has changes, then check with a dialog.
+        // When something has changes, then check with a dialog.
         // otherwise, go back to the item detail screen.
         credentialsToSave?.let { DialogAction.DiscardChangesDialog(itemId) }
             ?: ItemDetailAction.EndEditing(itemId)

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -33,6 +33,7 @@ interface EditItemDetailView {
     var isPasswordVisible: Boolean
     val togglePasswordClicks: Observable<Unit>
     val togglePasswordVisibility: Observable<Unit>
+    val usernameFieldClicks: Observable<Unit>
     val closeEntryClicks: Observable<Unit>
     val saveEntryClicks: Observable<Unit>
     val hostnameChanged: Observable<String>
@@ -43,6 +44,7 @@ interface EditItemDetailView {
     fun displayUsernameError(@StringRes errorMessage: Int? = null)
     fun displayPasswordError(@StringRes errorMessage: Int? = null)
     fun setSaveEnabled(enabled: Boolean)
+    fun setTextSelectionOnPasswordToggle()
 }
 
 @ExperimentalCoroutinesApi
@@ -129,8 +131,18 @@ class EditItemPresenter(
             .addTo(compositeDisposable)
 
         view.togglePasswordClicks
-            .map { ItemDetailAction.SetPasswordVisibility(view.isPasswordVisible.not()) }
-            .subscribe(dispatcher::dispatch)
+            .subscribe {
+                dispatcher.dispatch(
+                    ItemDetailAction.SetPasswordVisibility(view.isPasswordVisible.not())
+                )
+                view.setTextSelectionOnPasswordToggle()
+            }
+            .addTo(compositeDisposable)
+
+        view.usernameFieldClicks
+            .subscribe {
+                view.setTextSelectionOnPasswordToggle()
+            }
             .addTo(compositeDisposable)
 
         view.closeEntryClicks

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -18,8 +18,8 @@ import mozilla.lockbox.R
 import mozilla.lockbox.action.DialogAction
 import mozilla.lockbox.action.ItemDetailAction
 import mozilla.lockbox.action.RouteAction
-import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.extensions.filter
+import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.extensions.toDetailViewModel
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
@@ -33,7 +33,6 @@ interface EditItemDetailView {
     var isPasswordVisible: Boolean
     val togglePasswordClicks: Observable<Unit>
     val togglePasswordVisibility: Observable<Unit>
-    val usernameFieldClicks: Observable<Unit>
     val closeEntryClicks: Observable<Unit>
     val saveEntryClicks: Observable<Unit>
     val hostnameChanged: Observable<String>
@@ -44,7 +43,6 @@ interface EditItemDetailView {
     fun displayUsernameError(@StringRes errorMessage: Int? = null)
     fun displayPasswordError(@StringRes errorMessage: Int? = null)
     fun setSaveEnabled(enabled: Boolean)
-    fun setTextSelectionToEndOfLine()
 }
 
 @ExperimentalCoroutinesApi
@@ -100,10 +98,10 @@ class EditItemPresenter(
         Observables.combineLatest(getItem, dataStore.list)
             .map { (item, list) ->
                 list.filter(
-                        hostname = item.hostname,
-                        httpRealm = item.httpRealm,
-                        formSubmitURL = item.formSubmitURL
-                    )
+                    hostname = item.hostname,
+                    httpRealm = item.httpRealm,
+                    formSubmitURL = item.formSubmitURL
+                )
                     .map { it.username }
                     .toSet()
                     .minus(item.username)
@@ -135,13 +133,6 @@ class EditItemPresenter(
                 dispatcher.dispatch(
                     ItemDetailAction.SetPasswordVisibility(view.isPasswordVisible.not())
                 )
-                view.setTextSelectionToEndOfLine()
-            }
-            .addTo(compositeDisposable)
-
-        view.usernameFieldClicks
-            .subscribe {
-                view.setTextSelectionToEndOfLine()
             }
             .addTo(compositeDisposable)
 
@@ -192,7 +183,7 @@ class EditItemPresenter(
     }
 
     private fun checkDismissChanges(itemId: String) =
-        // When something has changes, then check with a dialog.
+    // When something has changes, then check with a dialog.
         // otherwise, go back to the item detail screen.
         credentialsToSave?.let { DialogAction.DiscardChangesDialog(itemId) }
             ?: ItemDetailAction.EndEditing(itemId)

--- a/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
@@ -197,7 +197,10 @@ class EditItemFragment : BackableFragment(), EditItemDetailView {
         }
     }
 
-    override fun setTextSelectionOnPasswordToggle() {
+    /**
+     *  Ensure that the text selector is at the end of the line when password visibility is toggled.
+     */
+    override fun setTextSelectionToEndOfLine() {
         view?.inputPassword?.setSelection(view?.inputPassword?.length() ?: 0)
     }
 

--- a/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
@@ -10,7 +10,6 @@ import android.os.Bundle
 import android.text.method.PasswordTransformationMethod
 import android.view.Gravity
 import android.view.LayoutInflater
-import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -127,10 +126,6 @@ class EditItemFragment : BackableFragment(), EditItemDetailView {
     }
 
     private fun setupKeyboardFocus(view: View) {
-//        else if (view?.inputUsername?.hasFocus() == true) {
-//            view?.inputUsername?.setSelection(view?.inputUsername?.length() ?: 0)
-//        }
-
         view.inputUsername.onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
             if (!hasFocus) {
                 closeKeyboard()

--- a/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.text.method.PasswordTransformationMethod
 import android.view.Gravity
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -38,6 +39,9 @@ class EditItemFragment : BackableFragment(), EditItemDetailView {
 
     override val togglePasswordClicks: Observable<Unit>
         get() = view!!.btnPasswordToggle.clicks()
+
+    override val usernameFieldClicks: Observable<Unit>
+        get() = view!!.inputUsername.clicks()
 
     override val closeEntryClicks: Observable<Unit>
         get() = view!!.toolbar.navigationClicks()
@@ -123,19 +127,37 @@ class EditItemFragment : BackableFragment(), EditItemDetailView {
     }
 
     private fun setupKeyboardFocus(view: View) {
-        val focusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
+//        else if (view?.inputUsername?.hasFocus() == true) {
+//            view?.inputUsername?.setSelection(view?.inputUsername?.length() ?: 0)
+//        }
+
+        view.inputUsername.onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
             if (!hasFocus) {
                 closeKeyboard()
+            } else {
+                view.inputUsername?.setSelection(view.inputUsername?.length() ?: 0)
             }
         }
 
-        view.inputUsername.onFocusChangeListener = focusChangeListener
+        view.fragment_item_edit.onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
+                closeKeyboard()
+            }
+        }
 
         view.inputPassword.onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
             togglePasswordVisibility.accept(Unit)
             if (!hasFocus) {
                 closeKeyboard()
+            } else {
+                view.inputPassword?.setSelection(view.inputPassword?.length() ?: 0)
             }
+        }
+
+        view.fragment_item_edit.setOnTouchListener { _, _ ->
+            closeKeyboard()
+            view.clearFocus()
+            true
         }
     }
 
@@ -178,6 +200,10 @@ class EditItemFragment : BackableFragment(), EditItemDetailView {
                 errorIconDrawable = null
             }
         }
+    }
+
+    override fun setTextSelectionOnPasswordToggle() {
+        view?.inputPassword?.setSelection(view?.inputPassword?.length() ?: 0)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/EditItemFragment.kt
@@ -39,9 +39,6 @@ class EditItemFragment : BackableFragment(), EditItemDetailView {
     override val togglePasswordClicks: Observable<Unit>
         get() = view!!.btnPasswordToggle.clicks()
 
-    override val usernameFieldClicks: Observable<Unit>
-        get() = view!!.inputUsername.clicks()
-
     override val closeEntryClicks: Observable<Unit>
         get() = view!!.toolbar.navigationClicks()
 
@@ -65,6 +62,8 @@ class EditItemFragment : BackableFragment(), EditItemDetailView {
         }
 
     private fun updatePasswordVisibility(visible: Boolean) {
+        view?.inputPassword?.setSelection(view?.inputPassword?.length() ?: 0)
+
         if (visible) {
             inputPassword.transformationMethod = null
             btnPasswordToggle.setImageResource(R.drawable.ic_hide)
@@ -195,13 +194,6 @@ class EditItemFragment : BackableFragment(), EditItemDetailView {
                 errorIconDrawable = null
             }
         }
-    }
-
-    /**
-     *  Ensure that the text selector is at the end of the line when password visibility is toggled.
-     */
-    override fun setTextSelectionToEndOfLine() {
-        view?.inputPassword?.setSelection(view?.inputPassword?.length() ?: 0)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -102,6 +102,7 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
 
     override fun showPopup() {
         val wrapper = ContextThemeWrapper(context, R.style.PopupKebabMenu)
+
         val popupMenu = PopupMenu(
             wrapper,
             this.kebabMenuButton,
@@ -123,7 +124,6 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
                 else -> false
             }
         }
-
         popupMenu.inflate(R.menu.item_detail_menu)
 
         val builder = popupMenu.menu as MenuBuilder

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -88,7 +88,7 @@
                 android:layout_height="wrap_content"
                 android:paddingTop="26dp"
                 android:paddingEnd="14dp"
-                android:paddingBottom="26dp"
+                android:paddingBottom="36dp"
                 tools:ignore="RtlSymmetry">
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -88,7 +88,9 @@
                 android:layout_height="wrap_content"
                 android:paddingTop="26dp"
                 android:paddingEnd="14dp"
-                android:paddingBottom="36dp"
+                android:paddingStart="16dp"
+
+                android:paddingBottom="32dp"
                 tools:ignore="RtlSymmetry">
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -105,7 +107,6 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:contentDescription="@string/launch_hostname_content_description"
-                        android:paddingStart="16dp"
                         android:paddingEnd="42dp"
                         android:scrollbars="none"
                         android:textColorHint="@color/black_60_percent"
@@ -137,7 +138,6 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_vertical"
                         android:background="@null"
-                        android:paddingStart="16dp"
                         android:paddingTop="8dp"
                         android:paddingEnd="16dp"
                         android:paddingBottom="8dp"
@@ -150,7 +150,7 @@
                 <View
                         android:layout_width="match_parent"
                         android:layout_height="1dp"
-                        android:layout_marginStart="18dp"
+                        android:layout_marginStart="4dp"
                         android:layout_marginTop="2dp"
                         android:layout_marginEnd="11dp"
                         android:background="@color/gray_divider"
@@ -168,17 +168,16 @@
                         android:id="@+id/inputLayoutUsername"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
+                        android:layout_marginTop="17dp"
                         android:layout_weight="1"
                         android:contentDescription="@string/copy_username_content_description"
-                        android:paddingStart="16dp"
+                        android:paddingTop="1dp"
                         android:paddingEnd="42dp"
                         android:textColorHint="@color/black_60_percent"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        tools:ignore="RtlSymmetry">
+                        app:layout_constraintTop_toTopOf="parent">
 
                     <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/inputUsername"
@@ -187,8 +186,10 @@
                             android:layout_height="wrap_content"
                             android:colorControlActivated="@color/violet_70"
                             android:ellipsize="end"
+                            android:layout_weight="1"
                             android:hint="@string/hint_username"
                             android:inputType="textNoSuggestions"
+                            android:paddingBottom="15dp"
                             android:lines="1"
                             app:layout_constraintEnd_toEndOf="@+id/inputLayoutUsername"
                             app:layout_constraintTop_toTopOf="@+id/inputLayoutUsername"
@@ -202,7 +203,7 @@
                         android:background="@null"
                         android:paddingTop="8dp"
                         android:paddingEnd="16dp"
-                        android:paddingBottom="8dp"
+                        android:paddingBottom="7dp"
                         app:layout_constraintBottom_toBottomOf="@+id/inputLayoutUsername"
                         app:layout_constraintRight_toRightOf="@+id/inputLayoutUsername"
                         app:layout_constraintTop_toTopOf="@+id/inputLayoutUsername"
@@ -212,9 +213,9 @@
                 <View
                         android:layout_width="match_parent"
                         android:layout_height="1dp"
-                        android:layout_marginStart="18dp"
-                        android:layout_marginTop="3dp"
+                        android:layout_marginTop="2dp"
                         android:layout_marginEnd="11dp"
+                        android:layout_marginStart="4dp"
                         android:background="@color/gray_divider"
                         card_view:layout_constraintTop_toBottomOf="@id/btnUsernameCopy" />
             </androidx.constraintlayout.widget.ConstraintLayout>
@@ -223,8 +224,7 @@
                     android:id="@+id/password"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginStart="16dp"
-                    android:layout_marginTop="16dp"
+                    android:layout_marginTop="13dp"
                     android:layout_marginEnd="12dp"
                     android:fontFamily="sans-serif"
                     android:orientation="horizontal"
@@ -250,7 +250,6 @@
                             android:id="@+id/inputPassword"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
-                            android:layout_gravity="center_vertical|start"
                             android:backgroundTint="@color/background_white"
                             android:clickable="true"
                             android:colorControlActivated="@color/violet_70"
@@ -261,6 +260,7 @@
                             android:isScrollContainer="false"
                             android:letterSpacing="0.01"
                             android:lineSpacingExtra="8sp"
+                            android:paddingBottom="16dp"
                             android:popupBackground="@android:color/transparent"
                             android:singleLine="true"
                             android:textColor="@color/black_87_percent"
@@ -278,7 +278,6 @@
                         android:contentDescription="@string/display_password_content_description"
                         android:paddingStart="16dp"
                         android:paddingTop="10dp"
-                        android:paddingBottom="8dp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toStartOf="@id/btnPasswordCopy"
                         app:layout_constraintTop_toTopOf="parent"
@@ -294,7 +293,6 @@
                         android:paddingStart="16dp"
                         android:paddingTop="8dp"
                         android:paddingEnd="4dp"
-                        android:paddingBottom="8dp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
@@ -303,8 +301,8 @@
                 <View
                         android:layout_width="match_parent"
                         android:layout_height="1dp"
-                        android:layout_marginStart="6dp"
-                        android:layout_marginTop="5dp"
+                        android:layout_marginStart="4dp"
+                        android:layout_marginTop="8dp"
                         android:background="@color/gray_divider"
                         card_view:layout_constraintTop_toBottomOf="@id/btnPasswordCopy" />
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -1,27 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ This Source Code Form is subject to the terms of the Mozilla Public
   ~  License, v. 2.0. If a copy of the MPL was not distributed with this
   ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/fragment_item_detail"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/fragment_item_detail"
         android:background="@color/background_grey"
         android:importantForAutofill="noExcludeDescendants"
         tools:ignore="UnusedAttribute">
 
-    <include layout="@layout/fragment_warning"
-             android:layout_width="match_parent"
-             android:layout_height="wrap_content"
-             app:layout_constraintTop_toBottomOf="@id/toolbar"
-             app:layout_constraintBottom_toTopOf="@id/cardView"
-             tools:text="@string/no_internet_connection"/>
+    <include
+            layout="@layout/fragment_warning"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toTopOf="@id/cardView"
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            tools:text="@string/no_internet_connection" />
 
     <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
@@ -29,53 +28,54 @@
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             android:theme="@style/ToolBar"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+            app:layout_constraintTop_toTopOf="parent">
+
         <androidx.constraintlayout.widget.ConstraintLayout
-                android:orientation="horizontal"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
-                <TextView
-                        android:id="@+id/entryTitle"
-                        android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        android:layout_weight="1"
-                        android:ellipsize="end"
-                        android:paddingEnd="50dp"
-                        android:maxLines="1"
-                        android:textSize="20sp"
-                        android:fontFamily="sans-serif-medium"
-                        android:textStyle="normal"
-                        android:textColor="@color/text_white"
-                        android:letterSpacing="0.01"
-                        android:layout_gravity="center_vertical|start"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        tools:ignore="RtlSymmetry"/>
-                <ImageButton
-                        android:id="@+id/kebabMenuButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textAllCaps="false"
-                        android:paddingTop="10dp"
-                        android:paddingBottom="10dp"
-                        android:visibility="gone"
-                        android:contentDescription="@string/kebab_menu"
-                        android:layout_marginEnd="14dp"
-                        android:textSize="20sp"
-                        android:background="@drawable/ic_menu_kebab"
-                        style="@style/PopupKebabMenu"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                />
+                android:layout_height="match_parent"
+                android:orientation="horizontal">
+
+            <TextView
+                    android:id="@+id/entryTitle"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center_vertical|start"
+                    android:layout_weight="1"
+                    android:ellipsize="end"
+                    android:fontFamily="sans-serif-medium"
+                    android:letterSpacing="0.01"
+                    android:maxLines="1"
+                    android:paddingEnd="50dp"
+                    android:textColor="@color/text_white"
+                    android:textSize="20sp"
+                    android:textStyle="normal"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:ignore="RtlSymmetry" />
+
+            <ImageButton
+                    android:id="@+id/kebabMenuButton"
+                    style="@style/PopupKebabMenu"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="14dp"
+                    android:background="@drawable/ic_menu_kebab"
+                    android:contentDescription="@string/kebab_menu"
+                    android:paddingTop="10dp"
+                    android:paddingBottom="10dp"
+                    android:textAllCaps="false"
+                    android:textSize="20sp"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.appcompat.widget.Toolbar>
 
-    <androidx.cardview.widget.CardView
-            xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    <androidx.cardview.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
             android:id="@+id/cardView"
             style="@style/EditItemDetail"
             android:layout_width="match_parent"
@@ -93,42 +93,42 @@
 
             <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/hostname"
-                    android:orientation="horizontal"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:layout_constraintTop_toTopOf="parent"
+                    android:orientation="horizontal"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent">
+                    app:layout_constraintTop_toTopOf="parent">
 
                 <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/inputLayoutHostname"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:scrollbars="none"
+                        android:contentDescription="@string/launch_hostname_content_description"
                         android:paddingStart="16dp"
                         android:paddingEnd="42dp"
+                        android:scrollbars="none"
                         android:textColorHint="@color/black_60_percent"
-                        android:contentDescription="@string/launch_hostname_content_description"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toStartOf="@id/btnHostnameLaunch"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
                         tools:ignore="RtlSymmetry">
 
                     <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/inputHostname"
-                            android:theme="@style/EditTextStyle"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="@string/hint_hostname"
-                            android:scrollHorizontally="true"
-                            android:lines="1"
-                            android:ellipsize="end"
-                            android:inputType="textNoSuggestions"
-                            android:textColor="@color/violet_70"
                             android:clickable="true"
-                            android:focusable="true"
                             android:colorControlActivated="@color/violet_70"
-                            tools:ignore="Autofill"/>
+                            android:ellipsize="end"
+                            android:focusable="true"
+                            android:hint="@string/hint_hostname"
+                            android:inputType="textNoSuggestions"
+                            android:lines="1"
+                            android:scrollHorizontally="true"
+                            android:textColor="@color/violet_70"
+                            android:theme="@style/EditTextStyle"
+                            tools:ignore="Autofill" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <ImageView
@@ -136,47 +136,48 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_vertical"
-                        android:paddingTop="8dp"
-                        android:paddingBottom="8dp"
-                        android:paddingStart="16dp"
-                        android:paddingEnd="16dp"
                         android:background="@null"
-                        tools:ignore="ContentDescription"
+                        android:paddingStart="16dp"
+                        android:paddingTop="8dp"
+                        android:paddingEnd="16dp"
+                        android:paddingBottom="8dp"
+                        app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:srcCompat="@drawable/ic_launch"/>
+                        app:srcCompat="@drawable/ic_launch"
+                        tools:ignore="ContentDescription" />
 
                 <View
-                        android:layout_height="1dp"
                         android:layout_width="match_parent"
-                        android:background="@color/gray_divider"
+                        android:layout_height="1dp"
                         android:layout_marginStart="18dp"
                         android:layout_marginTop="2dp"
                         android:layout_marginEnd="11dp"
+                        android:background="@color/gray_divider"
                         app:layout_constraintTop_toBottomOf="@id/btnHostnameLaunch" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/username"
-                    android:orientation="horizontal"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
+                    android:orientation="horizontal"
                     app:layout_constraintTop_toBottomOf="@id/hostname">
+
                 <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/inputLayoutUsername"
-                        android:contentDescription="@string/copy_username_content_description"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="16dp"
+                        android:layout_weight="1"
+                        android:contentDescription="@string/copy_username_content_description"
                         android:paddingStart="16dp"
                         android:paddingEnd="42dp"
-                        android:layout_weight="1"
                         android:textColorHint="@color/black_60_percent"
-                        app:layout_constraintTop_toTopOf="parent"
                         app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
                         tools:ignore="RtlSymmetry">
 
                     <com.google.android.material.textfield.TextInputEditText
@@ -184,87 +185,88 @@
                             style="@style/EditTextStyle"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:colorControlActivated="@color/violet_70"
+                            android:ellipsize="end"
                             android:hint="@string/hint_username"
                             android:inputType="textNoSuggestions"
                             android:lines="1"
-                            android:ellipsize="end"
-                            android:colorControlActivated="@color/violet_70"
                             app:layout_constraintEnd_toEndOf="@+id/inputLayoutUsername"
                             app:layout_constraintTop_toTopOf="@+id/inputLayoutUsername"
-                            tools:ignore="Autofill"/>
+                            tools:ignore="Autofill" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <ImageView
                         android:id="@+id/btnUsernameCopy"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:paddingTop="8dp"
-                        android:paddingBottom="8dp"
-                        android:paddingEnd="16dp"
                         android:background="@null"
-                        tools:ignore="ContentDescription,RtlSymmetry"
+                        android:paddingTop="8dp"
+                        android:paddingEnd="16dp"
+                        android:paddingBottom="8dp"
                         app:layout_constraintBottom_toBottomOf="@+id/inputLayoutUsername"
                         app:layout_constraintRight_toRightOf="@+id/inputLayoutUsername"
                         app:layout_constraintTop_toTopOf="@+id/inputLayoutUsername"
-                        app:srcCompat="@drawable/ic_copy"/>
+                        app:srcCompat="@drawable/ic_copy"
+                        tools:ignore="ContentDescription,RtlSymmetry" />
 
                 <View
-                        android:layout_height="1dp"
                         android:layout_width="match_parent"
-                        android:background="@color/gray_divider"
+                        android:layout_height="1dp"
                         android:layout_marginStart="18dp"
                         android:layout_marginTop="3dp"
                         android:layout_marginEnd="11dp"
+                        android:background="@color/gray_divider"
                         card_view:layout_constraintTop_toBottomOf="@id/btnUsernameCopy" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/password"
-                    android:orientation="horizontal"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
+                    android:layout_marginStart="16dp"
                     android:layout_marginTop="16dp"
                     android:layout_marginEnd="12dp"
-                    android:layout_marginStart="16dp"
                     android:fontFamily="sans-serif"
+                    android:orientation="horizontal"
                     app:layout_constraintTop_toBottomOf="@id/username"
-                    card_view:layout_constraintStart_toStartOf="parent"
-                    card_view:layout_constraintEnd_toEndOf="parent">
+                    card_view:layout_constraintEnd_toEndOf="parent"
+                    card_view:layout_constraintStart_toStartOf="parent">
+
                 <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/inputLayoutPassword"
                         android:layout_width="0dp"
                         android:layout_height="match_parent"
                         android:layout_marginTop="5dp"
                         android:layout_weight="1"
-                        android:textColorHint="@color/black_60_percent"
                         android:contentDescription="@string/copy_password_content_description"
+                        android:textColorHint="@color/black_60_percent"
+                        app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintBottom_toBottomOf="parent"
                         card_view:layout_constraintEnd_toStartOf="@id/btnPasswordToggle"
-                        tools:ignore="RtlSymmetry" >
-                        <com.google.android.material.textfield.TextInputEditText
-                                android:id="@+id/inputPassword"
-                                android:layout_width="match_parent"
-                                android:layout_height="match_parent"
-                                android:letterSpacing="0.01"
-                                android:ellipsize="end"
-                                android:singleLine="true"
-                                android:backgroundTint="@color/background_white"
-                                android:popupBackground="@android:color/transparent"
-                                android:layout_gravity="center_vertical|start"
-                                android:hint="@string/hint_password"
-                                android:isScrollContainer="false"
-                                android:fontFamily="monospace"
-                                android:lineSpacingExtra="8sp"
-                                android:textSize="16sp"
-                                android:textStyle="normal"
-                                android:textColor="@color/black_87_percent"
-                                android:clickable="true"
-                                android:focusable="true"
-                                android:colorControlActivated="@color/violet_70"
-                                tools:ignore="Autofill"
-                        />
+                        tools:ignore="RtlSymmetry">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/inputPassword"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:layout_gravity="center_vertical|start"
+                            android:backgroundTint="@color/background_white"
+                            android:clickable="true"
+                            android:colorControlActivated="@color/violet_70"
+                            android:ellipsize="end"
+                            android:focusable="true"
+                            android:fontFamily="monospace"
+                            android:hint="@string/hint_password"
+                            android:isScrollContainer="false"
+                            android:letterSpacing="0.01"
+                            android:lineSpacingExtra="8sp"
+                            android:popupBackground="@android:color/transparent"
+                            android:singleLine="true"
+                            android:textColor="@color/black_87_percent"
+                            android:textSize="16sp"
+                            android:textStyle="normal"
+                            tools:ignore="Autofill" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <ImageButton
@@ -272,36 +274,38 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginEnd="16dp"
-                        android:paddingBottom="8dp"
-                        android:paddingTop="10dp"
-                        android:paddingStart="16dp"
                         android:background="@null"
                         android:contentDescription="@string/display_password_content_description"
-                        app:layout_constraintTop_toTopOf="parent"
+                        android:paddingStart="16dp"
+                        android:paddingTop="10dp"
+                        android:paddingBottom="8dp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toStartOf="@id/btnPasswordCopy"
-                        card_view:layout_constraintStart_toEndOf="@id/inputLayoutPassword"
-                        app:srcCompat="@drawable/ic_show"/>
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:srcCompat="@drawable/ic_show"
+                        card_view:layout_constraintStart_toEndOf="@id/inputLayoutPassword" />
+
                 <ImageButton
                         android:id="@+id/btnPasswordCopy"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:paddingTop="8dp"
-                        android:paddingBottom="8dp"
-                        android:paddingStart="16dp"
-                        android:paddingEnd="4dp"
                         android:background="@null"
                         android:contentDescription="@string/copy_password_content_description"
-                        app:layout_constraintTop_toTopOf="parent"
+                        android:paddingStart="16dp"
+                        android:paddingTop="8dp"
+                        android:paddingEnd="4dp"
+                        android:paddingBottom="8dp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:srcCompat="@drawable/ic_copy"/>
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:srcCompat="@drawable/ic_copy" />
+
                 <View
-                        android:layout_height="1dp"
                         android:layout_width="match_parent"
-                        android:background="@color/gray_divider"
+                        android:layout_height="1dp"
                         android:layout_marginStart="6dp"
                         android:layout_marginTop="5dp"
+                        android:background="@color/gray_divider"
                         card_view:layout_constraintTop_toBottomOf="@id/btnPasswordCopy" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_item_edit.xml
+++ b/app/src/main/res/layout/fragment_item_edit.xml
@@ -124,6 +124,7 @@
                             android:textSize="16sp"
                             android:fontFamily="sans-serif"
                             android:textStyle="normal"
+                            android:paddingBottom="13dp"
                             android:textColor="@color/gray_73_percent"
                             android:textColorHint="@color/black_60_percent"
                             android:colorControlHighlight="@color/black_60_percent"
@@ -149,6 +150,7 @@
                     android:id="@+id/entryUsername"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:foregroundGravity="center_vertical"
                     android:layout_marginTop="16dp"
                     android:layout_marginEnd="16dp"
                     app:layout_constraintTop_toBottomOf="@id/entryHostname" >
@@ -157,6 +159,7 @@
                         android:id="@+id/inputLayoutUsername"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_weight="1"
                         android:paddingStart="16dp"
                         android:textColorHint="@color/black_60_percent"
                         android:colorControlActivated="@color/violet_70"
@@ -180,11 +183,13 @@
                             android:inputType="textNoSuggestions"
                             android:singleLine="true"
                             android:ellipsize="end"
+                            android:drawablePadding="5dp"
+                            android:paddingBottom="14dp"
                             android:maxLines="1"
                             android:clickable="true"
                             android:focusable="true"
                             app:backgroundTint="@color/gray_divider"
-                            tools:ignore="Autofill"/>
+                            tools:ignore="Autofill" />
                 </com.google.android.material.textfield.TextInputLayout>
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -196,7 +201,6 @@
                     android:paddingEnd="16dp"
                     android:fontFamily="sans-serif"
                     app:layout_constraintTop_toBottomOf="@id/entryUsername" >
-
                 <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/inputLayoutPassword"
                         android:layout_width="match_parent"
@@ -213,7 +217,7 @@
 
                     <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/inputPassword"
-                            android:textSize="15sp"
+                            android:textSize="16sp"
                             android:textStyle="normal"
                             android:textColor="@color/black_87_percent"
                             android:lineSpacingExtra="8sp"
@@ -226,6 +230,8 @@
                             android:singleLine="true"
                             android:clickable="true"
                             android:focusable="true"
+                            android:paddingBottom="12dp"
+                            android:foregroundGravity="center_vertical"
                             app:backgroundTint="@android:color/transparent"
                             tools:ignore="Autofill"/>
                 </com.google.android.material.textfield.TextInputLayout>
@@ -234,8 +240,8 @@
                         android:id="@+id/btnPasswordToggle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginEnd="5dp"
-                        android:layout_marginBottom="8dp"
+                        android:layout_marginEnd="10dp"
+                        android:layout_marginBottom="13dp"
                         android:background="@null"
                         android:foregroundGravity="center_horizontal|center_vertical"
                         android:contentDescription="@string/display_password_content_description"
@@ -249,8 +255,8 @@
                         android:layout_width="match_parent"
                         android:background="@color/gray_divider"
                         android:layout_marginStart="20dp"
-                        android:layout_marginEnd="2dp"
-                        android:layout_marginTop="9dp"
+                        android:layout_marginEnd="4dp"
+                        android:layout_marginTop="9.5dp"
                         card_view:layout_constraintTop_toBottomOf="@id/btnPasswordToggle" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_item_edit.xml
+++ b/app/src/main/res/layout/fragment_item_edit.xml
@@ -17,6 +17,8 @@
         android:windowSoftInputMode="adjustPan"
         android:fitsSystemWindows="true"
         android:windowActionBarOverlay="true"
+        android:clickable="true"
+        android:focusable="true"
         android:importantForAutofill="noExcludeDescendants"
         tools:ignore="UnusedAttribute"
         style="@style/EditItemDetail">
@@ -97,6 +99,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingEnd="16dp"
+                    android:clickable="false"
+                    android:focusable="false"
                     app:layout_constraintTop_toTopOf="parent" >
 
                 <com.google.android.material.textfield.TextInputLayout
@@ -104,6 +108,8 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:paddingStart="16dp"
+                        android:clickable="false"
+                        android:focusable="false"
                         android:colorControlHighlight="@color/black_60_percent"
                         android:colorControlActivated="@color/black_60_percent"
                         android:textColorHint="@color/black_60_percent"
@@ -120,6 +126,8 @@
                             android:textStyle="normal"
                             android:textColor="@color/gray_73_percent"
                             android:textColorHint="@color/black_60_percent"
+                            android:colorControlHighlight="@color/black_60_percent"
+                            android:colorControlActivated="@color/black_60_percent"
                             android:letterSpacing="0.01"
                             android:lineSpacingExtra="8sp"
                             android:layout_width="match_parent"
@@ -136,7 +144,6 @@
                             tools:ignore="Autofill"/>
                 </com.google.android.material.textfield.TextInputLayout>
             </androidx.constraintlayout.widget.ConstraintLayout>
-
 
             <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/entryUsername"
@@ -214,6 +221,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:hint="@string/hint_password"
+                            android:inputType="textNoSuggestions"
                             android:colorControlActivated="@color/violet_70"
                             android:singleLine="true"
                             android:clickable="true"

--- a/app/src/main/res/menu/item_detail_menu.xml
+++ b/app/src/main/res/menu/item_detail_menu.xml
@@ -7,14 +7,14 @@
 <menu
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/item_detail_menu"
-        android:theme="@style/PopupKebabMenu"
-        android:layout_width="wrap_content"
-        android:dropDownWidth="wrap_content" >
+        android:popupMenuStyle="@style/PopupKebabMenu"
+        android:theme="@style/PopupKebabMenu">
     <item
             android:id="@+id/edit"
             android:icon="@drawable/ic_edit"
             android:padding="20dp"
             android:elevation="15dp"
+            android:minWidth="82dp"
             android:paddingStart="20dp"
             android:title="@string/edit"
             android:colorBackground="@color/menu_item_selected"
@@ -24,5 +24,9 @@
     <item
             android:id="@+id/delete"
             android:icon="@drawable/ic_delete"
-            android:title="@string/delete" />
+            android:title="@string/delete"
+            android:minWidth="82dp"
+            android:colorBackground="@color/menu_item_selected"
+            android:textColor="@color/black_87_percent"
+            android:listSelector="@color/menu_item_selected"/>
 </menu>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -190,6 +190,7 @@
         <item name="colorAccent">@color/violet_70</item>
         <item name="buttonBarButtonStyle">@style/AlertButtonStyle</item>
     </style>
+
     <style name="DeleteDialogStyle" parent="Theme.AppCompat.Light.Dialog">
         <item name="android:windowBackground">@drawable/rounded_corner_bg_white</item>
         <item name="android:textColorPrimary">@color/black_60_percent</item>
@@ -197,6 +198,7 @@
         <item name="buttonBarButtonStyle">@style/AlertButtonStyle</item>
         <item name="android:lineSpacingExtra">8sp</item>
     </style>
+
     <style name="AlertButtonStyle" parent="Widget.AppCompat.Button.Borderless">
         <item name="android:textColor">@color/violet_70</item>
         <item name="android:letterSpacing">0.09</item>
@@ -205,6 +207,7 @@
         <item name="android:textSize">14sp</item>
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
+
     <style name="NavDrawerStyle" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:textSize">16sp</item>
         <item name="android:fontFamily">sans-serif-medium</item>
@@ -212,6 +215,7 @@
         <item name="android:lineSpacingExtra">6.5sp</item>
         <item name="android:drawableTint">@color/color_primary_dark</item>
     </style>
+
     <style name="NavDrawerButtonStyle" parent="Widget.AppCompat.Button.Borderless">
         <item name="android:textSize">16sp</item>
         <item name="android:textAllCaps">false</item>
@@ -221,6 +225,7 @@
         <item name="android:stateListAnimator">@null</item>
         <item name="android:drawableTint">@color/color_primary_dark</item>
     </style>
+
     <style name="NoTitleDialog" parent="@android:style/Theme.Dialog">
         <item name="android:windowFrame">@null</item>
         <item name="android:windowNoTitle">true</item>
@@ -229,6 +234,7 @@
         <item name="android:background">@android:color/transparent</item>
         <item name="android:popupBackground">@android:color/transparent</item>
     </style>
+
     <style name="PopupMenu" parent="@style/Widget.AppCompat.PopupWindow">
         <item name="android:popupBackground">@null</item>
         <item name="android:background">@drawable/rounded_corner_bg_white</item>
@@ -236,7 +242,6 @@
         <item name="android:textColor">@color/black_87_percent</item>
         <item name="android:textSize">14sp</item>
         <item name="android:fontFamily">sans-serif</item>
-        <item name="android:dropDownWidth">128dp</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
         <item name="android:lineSpacingExtra">6sp</item>
@@ -247,6 +252,7 @@
         <item name="android:popupElevation">14dp</item>
         <item name="android:elevation">0dp</item>
     </style>
+
     <style name="PopupKebabMenu" parent="@style/Widget.AppCompat.PopupWindow">
         <item name="android:popupBackground">@null</item>
         <item name="android:background">@drawable/rounded_corner_bg_white</item>
@@ -256,6 +262,7 @@
         <item name="android:textSize">14sp</item>
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:dropDownWidth">wrap_content</item>
+        <item name="android:minWidth">20dp</item>
         <item name="android:textStyle">normal</item>
         <item name="android:letterSpacing">0.02</item>
         <item name="android:lineSpacingExtra">6sp</item>
@@ -266,12 +273,14 @@
         <item name="android:popupElevation">20dp</item>
         <item name="android:elevation">0dp</item>
     </style>
+
     <style name="ToastTextAppearance" parent="@style/TextAppearance">
         <item name="android:background">@android:color/transparent</item>
         <item name="android:textColor">@color/text_white</item>
         <item name="android:layout_marginStart">20dp</item>
         <item name="android:layout_marginEnd">20dp</item>
     </style>
+
     <style name="NoConnectivityWarning">
         <item name="android:background">@color/color_primary_dark</item>
     </style>

--- a/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
@@ -103,8 +103,9 @@ class EditItemPresenterTest {
             _saveEnabled = enabled
         }
 
-        override fun setTextSelectionOnPasswordToggle() {
+        override fun setTextSelectionToEndOfLine() {
             // make sure the text selector is at the end of the line when password is toggled
+            // or a field is selected
             // NOOP
         }
     }

--- a/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
@@ -64,10 +64,6 @@ class EditItemPresenterTest {
         override val usernameChanged: Observable<String>
             get() = usernameClicksStub
 
-        private val usernameFieldClicksStub = PublishSubject.create<Unit>()
-        override val usernameFieldClicks: Observable<Unit>
-            get() = usernameFieldClicksStub
-
         val pwdClicksStub = PublishSubject.create<String>()
         override val passwordChanged: Observable<String>
             get() = pwdClicksStub
@@ -77,8 +73,10 @@ class EditItemPresenterTest {
         }
 
         var item: ItemDetailViewModel? = null
-        @StringRes var usernameError: Int? = null
-        @StringRes var passwordError: Int? = null
+        @StringRes
+        var usernameError: Int? = null
+        @StringRes
+        var passwordError: Int? = null
         var _saveEnabled = true
 
         val closeEntryClicksStub = PublishSubject.create<Unit>()
@@ -96,17 +94,13 @@ class EditItemPresenterTest {
         override fun displayUsernameError(@StringRes errorMessage: Int?) {
             usernameError = errorMessage
         }
+
         override fun displayPasswordError(@StringRes errorMessage: Int?) {
             passwordError = errorMessage
         }
+
         override fun setSaveEnabled(enabled: Boolean) {
             _saveEnabled = enabled
-        }
-
-        override fun setTextSelectionToEndOfLine() {
-            // make sure the text selector is at the end of the line when password is toggled
-            // or a field is selected
-            // NOOP
         }
     }
 
@@ -183,10 +177,12 @@ class EditItemPresenterTest {
         subject.onViewReady()
 
         getStub.onNext(item.asOptional())
-        listStub.onNext(listOf(
-            fakeCredential,
-            fakeCredentialNoUsername
-        ))
+        listStub.onNext(
+            listOf(
+                fakeCredential,
+                fakeCredentialNoUsername
+            )
+        )
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
@@ -45,24 +45,28 @@ class EditItemPresenterTest {
 
     class FakeView : EditItemDetailView {
 
-        val togglePasswordVisibilityStub = PublishSubject.create<Unit>()
+        private val togglePasswordVisibilityStub = PublishSubject.create<Unit>()
         override val togglePasswordVisibility: Observable<Unit>
             get() = togglePasswordVisibilityStub
 
-        val passwordVisibleStub = false
+        private val passwordVisibleStub = false
         override var isPasswordVisible: Boolean = passwordVisibleStub
 
-        val togglePwdClicksStub = PublishSubject.create<Unit>()
+        private val togglePwdClicksStub = PublishSubject.create<Unit>()
         override val togglePasswordClicks: Observable<Unit>
             get() = togglePwdClicksStub
 
-        val hostnameClicksStub = PublishSubject.create<String>()
+        private val hostnameClicksStub = PublishSubject.create<String>()
         override val hostnameChanged: Observable<String>
             get() = hostnameClicksStub
 
         val usernameClicksStub = PublishSubject.create<String>()
         override val usernameChanged: Observable<String>
             get() = usernameClicksStub
+
+        private val usernameFieldClicksStub = PublishSubject.create<Unit>()
+        override val usernameFieldClicks: Observable<Unit>
+            get() = usernameFieldClicksStub
 
         val pwdClicksStub = PublishSubject.create<String>()
         override val passwordChanged: Observable<String>
@@ -97,6 +101,11 @@ class EditItemPresenterTest {
         }
         override fun setSaveEnabled(enabled: Boolean) {
             _saveEnabled = enabled
+        }
+
+        override fun setTextSelectionOnPasswordToggle() {
+            // make sure the text selector is at the end of the line when password is toggled
+            // NOOP
         }
     }
 


### PR DESCRIPTION
Fixes #991

## Testing and Review Notes
Putting screenshots in a comment further down so I don't clutter this up too much...

## Screenshots or Videos

Taps on edit don't highlight the `hostname` underline anymore (not much to see here...)
<img width="350" alt="taps_edit" src="https://user-images.githubusercontent.com/43795363/69378085-351bad00-0c73-11ea-8a7f-a3f7badc12d6.gif"> 

Selecting username moves cursor to the end. Toggling password moves cursor to the end.
<img width="350" alt="toggle_pwd_clicks" src="https://user-images.githubusercontent.com/43795363/69378102-45338c80-0c73-11ea-8966-8a9465eaa721.gif"> 

Dismiss keyboard easily
<img width="350" alt="dismiss_keyboard" src="https://user-images.githubusercontent.com/43795363/69378284-b96e3000-0c73-11ea-925a-d72e9b06d8fd.gif">


## Todo

~**item detail**:~
- [ ] ~kebab menu transitions~
- [ ] ~move kebab menu 4dp from side~
- [ ] ~click listeners not registering correct item ids~
Moved to #1077


**misc**: 
- [ ] do we have an issue to handle the metadata showing on a login detail screen below the fields?
   * open question on this


## Done
- [ ] ~if possible, match width of edit menu popup to spec (128dp) and only grow if needed for localization~
   * duplicate of above
- [x] padding around edit fields
- [ ] ~horizontal line tap state (thick purple line) needs to go all the way across. currently it is stopping where the icon bounding box begins~
   * if we want wrapping to a single line and no text overlapping with buttons it has to be this way
- [ ] ~the horizontal line tap state (thick purple line) needs to completely overlap the default grey line; currently it is resting slightly above the grey line~
   * see above
- [ ] ~There's a square white background on the cursor tap indicator (when first tapping into a field)~
   * fixed in #1061 
- [x] If you tap into a field, evoking the blinking vertical line, but then collapse the keyboard, the blinking vertical line remains in the field, still blinking
- [ ] ~Tapping anywhere in the edit view that isn't a field (in the white space of the card or the grey background) selects the line for Name (which should be a disabled field)~
   * removed name field in #1025 
- [x] Toggling between hiding and showing a password in the field moves the text cursor between the start and the end of the string; it should stay at the end of the string
- [x] It is difficult to dismiss the keyboard without tapping it away within the base bar; the login details do not scroll while the keyboard is active; is this expected behavior?
- [x] typing into the username and tapping the --> at the base of the keyboard should close the keyboard, rather than moving to the next field 
- [x] the text line cursor always needs to be initially displayed at the end of the string, not the beginning
- [ ] keyboard enter button is green, it should be violet70 -> need to look into this more
   * https://stackoverflow.com/questions/28899995/how-to-change-color-of-soft-keyboard-enter-next-button-on-lollipop
   * https://stackoverflow.com/questions/15789997/how-to-change-background-color-of-key-for-android-soft-keyboard
   * would have to implement a new keyboard 🤔 
- [x] Format strings and give them descriptions
- [x] toolbar title should be Edit Login
- [x] make password hint `sans-serif` while the password is `monopace`
- [x] disable ☑️ save when errors are present
- [x] fix pwd button toggling (make it T/F instead of .not()ing)
- [x] long username ... on item list
- [x] no additional lines in between hostname/username/pwd
- [x] lines between item details change to violet70 when pressed
- [x] Item Detail view: https://zpl.io/blDkLPv
   - ~icons needed for both edit and delete~
   - ~position of dropdown should be over the top of the ellipsis, not below~
   - ~width of dropdown should be 128dp (grow to expand if needed for longer localized strings)~
   - ~shadow is stronger in design spec (8dp)~
   - dropdown does not align to far right side, it floats 4px from edge
- [x] Edit view: https://zpl.io/boDxOPX
   - ~confirm label size is 12sp~
   - ~labels need letter spacing of 0.4sp -> using the same formatting as item detail view~
   - ~“Delete Entry” requires top and bottom padding (40dp on top, 30dp on bottom)~
   - ~confirm color of Delete text is #d70022~
- [x] Editing an entry: https://zpl.io/bLdGW5G
   - ~Web Address label color should be violet70~
   - ~form field selected line should be violet70~
   - ~form field selected line and base line of web address field should be one and the same (not 2 different lines)~
- [x] remove the “Learn how to edit this login” link
- [x] monospace font for password (de-compress the dots)
- [ ] ~fields "jumping" with error states~
   * not valid anymore since we removed name and hostname edits

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
