### PR TITLE
Integrate the Glean SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,7 @@ plugins {
     id 'kotlin-android'
     id 'io.sentry.android.gradle'
     id 'jacoco'
+    id "com.jetbrains.python.envs" version "0.0.26"
 }
 
 android {
@@ -103,6 +104,7 @@ dependencies {
     implementation "org.mozilla.components:service-sync-logins:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:service-firefox-accounts:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:service-telemetry:${rootProject.ext.android_components_version}"
+    implementation "org.mozilla.components:service-glean:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-dataprotect:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-publicsuffixlist:${rootProject.ext.android_components_version}"
@@ -260,6 +262,11 @@ if (project.hasProperty("coverage")) {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions.allWarningsAsErrors = true
 }
+
+// Generate markdown docs for the collected metrics.
+ext.gleanGenerateMarkdownDocs = true
+ext.gleanDocsDirectory = "$rootDir/docs/glean"
+apply from: 'https://github.com/mozilla-mobile/android-components/raw/v' + rootProject.ext.android_components_version + '/components/service/glean/scripts/sdk_generator.gradle'
 
 // Internal, but stable and convenient.
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -5,8 +5,9 @@ _Last Updated: Feb 4, 2019_
 <!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Analysis](#analysis)
-- [Collection](#collection)
+- [Collection](#collection-legacy)
 - [List of Implemented Events](#list-of-implemented-events)
+- [Mozilla Glean SDK](#mozilla-glean-sdk)
 - [Adjust SDK](#adjust-sdk)
 - [References](#references)
 
@@ -50,7 +51,7 @@ In service to validating the above hypothesis, we plan on answering these specif
 
 In addition to answering the above questions that directly concern actions in the app, we will also analyze telemetry emitted from the password manager that exists in the the Firefox desktop browser. These analyses will primarily examine whether users of Lockwise start active curation of their credentials in the desktop browser (Lockwise users will not be able to edit credentials directly from the app).
 
-## Collection
+## Collection (legacy)
 
 *Note: There is currently a new Mozilla mobile telemetry SDK under development, however it will not ship prior to the Lockwise for Android app. Once the new SDK ships we will evaluate whether or not to tear out the old implementation and replace it with the new SDK.*
 
@@ -179,6 +180,15 @@ https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/c
 	* `value`: null
 	* `extras`: null
 
+## Mozilla Glean SDK
+
+Lockwise for Android uses the [Glean SDK](https://mozilla.github.io/glean/book/index.html) to collect telemetry. The Glean SDK provides a handful of [pings and metrics out of the box](https://mozilla.github.io/glean/book/user/pings/index.html). The data review for using the Glean SDK is available at [this link](TODO).
+
+Lockwise for Android also uses the following Glean-enabled components of [Android Components](https://github.com/mozilla-mobile/android-components/), which are sending telemetry:
+
+|Name|Description|Collected metrics|Data review|
+|---|---|---|---|
+|[Firefox accounts](https://github.com/mozilla-mobile/android-components/tree/master/components/service/firefox-accounts)|A library for integrating with Firefox Accounts.| [docs](https://github.com/mozilla-mobile/android-components/blob/master/components/support/sync-telemetry/docs/metrics.md)| [review](TODO) |
 
 ## Adjust SDK
 
@@ -186,7 +196,9 @@ The app also includes a version of the [adjust SDK](https://github.com/adjust/an
 
 ## References
 
-[Library used to collect and send telemetry on Android](https://github.com/mozilla-mobile/android-components/blob/master/components/service/telemetry/README.md)
+[Glean SDK repository, used to collect and send telemetry](https://github.com/mozilla/glean/)
+
+[Legacy library used to collect and send telemetry on Android](https://github.com/mozilla-mobile/android-components/blob/master/components/service/telemetry/README.md)
 
 [Description of the "Core" ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/core-ping.html)
 


### PR DESCRIPTION
This PR adds the Glean SDK as a dependency and enables it. It additionally adds basic documentation in the `docs/metrics.md`.

This is based off #1070 and requires rebasing after that gets merged.

Fixes #127

**TODO**

- [ ] Figure out how to get the initial value for the data collection preference.
- [x] Figure out how to get updates for the data collection preference.