### PR TITLE
Cn beta rxu

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>

--- a/app/src/main/java/mozilla/lockbox/action/SettingAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/SettingAction.kt
@@ -18,6 +18,7 @@ open class SettingAction(
     data class UnlockWithFingerprint(val unlockWithFingerprint: Boolean) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_fingerprint, unlockWithFingerprint.toString())
     data class UnlockWithFingerprintPendingAuth(val unlockWithFingerprintPendingAuth: Boolean) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_fingerprint_pending_auth, unlockWithFingerprintPendingAuth.toString())
     data class SendUsageData(val sendUsageData: Boolean) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_record_usage_data, null)
+    data class UseLocalService(val useLocalService: Boolean) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_use_local_service, null)
     data class ItemListSortOrder(val sortOrder: Setting.ItemListSort) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_item_list_order, null)
     data class AutoLockTime(val time: Setting.AutoLockTime) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_autolock_time, time.seconds.toString())
     data class Autofill(val enable: Boolean) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_autofill, null)

--- a/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
@@ -73,6 +73,7 @@ enum class TelemetryEventObject {
     settings_autolock,
     settings_reset,
     settings_record_usage_data,
+    settings_use_local_service,
     settings_account,
     settings_faq,
     settings_provide_feedback,

--- a/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
@@ -122,6 +122,7 @@ class AppRoutePresenter(
             R.id.fragment_welcome to R.id.fragment_fxa_login -> R.id.action_welcome_to_fxaLogin
             R.id.fragment_welcome to R.id.fragment_item_list -> R.id.action_welcome_to_autoLogin
             R.id.fragment_welcome to R.id.fragment_webview -> R.id.action_welcome_to_faq
+            R.id.fragment_welcome to R.id.fragment_setting -> R.id.action_welcome_to_settings
 
             R.id.fragment_fxa_login to R.id.fragment_item_list -> R.id.action_fxaLogin_to_itemList
             R.id.fragment_fxa_login to R.id.fragment_fingerprint_onboarding -> R.id.action_fxaLogin_to_fingerprint_onboarding

--- a/app/src/main/java/mozilla/lockbox/presenter/WelcomePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/WelcomePresenter.kt
@@ -24,6 +24,8 @@ interface WelcomeView {
     val getStartedAutomaticallyClicks: Observable<Unit>
     val getStartedManuallyClicks: Observable<Unit>
     val learnMoreClicks: Observable<Unit>
+    val switchServiceClicks: Observable<Unit>
+    fun hideSwitchService()
     fun showExistingAccount(email: String)
     fun hideExistingAccount()
 }
@@ -31,6 +33,7 @@ interface WelcomeView {
 @ExperimentalCoroutinesApi
 class WelcomePresenter(
     private val view: WelcomeView,
+    private val chinaBuild: Boolean,
     private val dispatcher: Dispatcher = Dispatcher.shared,
     private val accountStore: AccountStore = AccountStore.shared,
     private val fingerprintStore: FingerprintStore = FingerprintStore.shared
@@ -51,6 +54,10 @@ class WelcomePresenter(
             view.hideExistingAccount()
         }
 
+        if (!chinaBuild) {
+            view.hideSwitchService()
+        }
+
         view.getStartedManuallyClicks
             .map {
                 routeToLoginManually()
@@ -62,6 +69,13 @@ class WelcomePresenter(
             .subscribe {
                 dispatcher.dispatch(AppWebPageAction.FaqWelcome)
             }
+            .addTo(compositeDisposable)
+
+        view.switchServiceClicks
+            .map {
+                RouteAction.SettingList
+            }
+            .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
     }
 

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -54,6 +54,8 @@ object Constant {
         val autoLockTime = Setting.AutoLockTime.FiveMinutes
         val noSecurityAutoLockTime = Setting.AutoLockTime.Never
         const val sendUsageData = true
+        const val useLocalServiceFalse = false
+        const val useLocalServiceTrue = true
         const val unlockWithFingerprint = false
     }
 

--- a/app/src/main/java/mozilla/lockbox/view/SettingFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/SettingFragment.kt
@@ -15,6 +15,7 @@ import android.view.ViewGroup
 import com.github.magiepooh.recycleritemdecoration.ItemDecorations
 import kotlinx.android.synthetic.main.fragment_setting.view.*
 import kotlinx.android.synthetic.main.list_cell_setting_toggle.view.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
 import mozilla.lockbox.adapter.SectionedAdapter
 import mozilla.lockbox.adapter.SettingCellConfiguration
@@ -24,6 +25,7 @@ import mozilla.lockbox.adapter.SettingListAdapter.Companion.SETTING_TOGGLE_TYPE
 import mozilla.lockbox.presenter.SettingPresenter
 import mozilla.lockbox.presenter.SettingView
 
+@ExperimentalCoroutinesApi
 class SettingFragment : BackableFragment(), SettingView {
 
     private val adapter = SettingListAdapter()
@@ -39,7 +41,10 @@ class SettingFragment : BackableFragment(), SettingView {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        presenter = SettingPresenter(this)
+        val chinaBuild = resources.configuration.locales.get(0).toString().equals("zh_CN_#Hans") &&
+            resources.configuration.locales.get(0).displayLanguage.equals("中文") &&
+            (!"com.android.vending".equals(context!!.packageManager.getInstallerPackageName(context!!.packageName)))
+        presenter = SettingPresenter(this, chinaBuild)
 
         // Inflate the layout for this fragment
         val view = inflater.inflate(R.layout.fragment_setting, container, false)

--- a/app/src/main/java/mozilla/lockbox/view/WelcomeFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/WelcomeFragment.kt
@@ -25,7 +25,10 @@ class WelcomeFragment : Fragment(), WelcomeView {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        presenter = WelcomePresenter(this)
+        val chinaBuild = resources.configuration.locales.get(0).toString().equals("zh_CN_#Hans") &&
+            resources.configuration.locales.get(0).displayLanguage.equals("中文") &&
+            (!"com.android.vending".equals(context!!.packageManager.getInstallerPackageName(context!!.packageName)))
+        presenter = WelcomePresenter(this, chinaBuild)
         val view = inflater.inflate(R.layout.fragment_welcome, container, false)
         val appLabel = getString(R.string.app_label)
         view.textViewInstructions.text = getString(R.string.welcome_instructions, appLabel)
@@ -53,6 +56,12 @@ class WelcomeFragment : Fragment(), WelcomeView {
         }
     }
 
+    override fun hideSwitchService() {
+        view?.apply {
+            textViewSwitchService.visibility = View.GONE
+        }
+    }
+
     override val getStartedAutomaticallyClicks: Observable<Unit>
         get() = view!!.buttonGetStarted.clicks()
 
@@ -61,4 +70,7 @@ class WelcomeFragment : Fragment(), WelcomeView {
 
     override val learnMoreClicks: Observable<Unit>
         get() = view!!.textViewLearnMore.clicks()
+
+    override val switchServiceClicks: Observable<Unit>
+        get() = view!!.textViewSwitchService.clicks()
 }

--- a/app/src/main/res/layout/fragment_welcome.xml
+++ b/app/src/main/res/layout/fragment_welcome.xml
@@ -134,5 +134,21 @@
             android:letterSpacing="0.04"
             android:layout_gravity="center"
         />
+
+        <TextView
+                android:id="@+id/textViewSwitchService"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="@string/welcome_switch_service_btn"
+                android:textStyle="bold"
+                android:textAllCaps="true"
+                android:background="@android:color/transparent"
+                android:textColor="@color/link_pressed"
+                android:textSize="12sp"
+                android:textAlignment="center"
+                android:letterSpacing="0.04"
+                android:layout_gravity="center"
+                />
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -69,6 +69,9 @@
                 android:id="@+id/action_welcome_to_fxaLogin"
                 app:destination="@id/fragment_fxa_login"/>
         <action
+                android:id="@+id/action_welcome_to_settings"
+                app:destination="@id/fragment_setting"/>
+        <action
                 android:id="@+id/action_welcome_to_faq"
                 app:destination="@id/fragment_webview"/>
         <action

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <!-- This is the link on the first-run welcome screen to learn more about the requirements of the application -->
     <string name="welcome_learn_more_btn">Learn More</string>
 
+    <string name="welcome_switch_service_btn" tools:ignore = "MissingTranslation">Switch Service</string>
     <!-- This is the label used for the title in the web view of the account's authentication instances. -->
     <string name="get_started_title">Get Started</string>
 
@@ -96,6 +97,7 @@
     <!-- This describes an icon to screenreaders that the button tapped will display the password in plain text for immediate reading or use -->
     <string name="display_password_content_description">Display your password in plain text</string>
 
+    <string name="service_title" tools:ignore= "MissingTranslation">Service</string>
     <!-- This is a heading that appears above a group of application settings to configure the user experience -->
     <string name="configuration_title">Configuration</string>
     <!-- This is a heading that appears above a group of application settings or links related to what is supported by the application -->
@@ -134,6 +136,8 @@
     <!-- This is the sub-title of a setting that allows the user to automatically fill forms in Android applications and websites using username and password data from this application -->
     <string name="send_usage_data_summary">Mozilla strives to only collect what we need to provide and improve Firefox for everyone. </string>
 
+    <string name="use_local_service" tools:ignore = "MissingTranslation">Use Local Service</string>
+    <string name="use_local_service_description" tools:ignore = "MissingTranslation">Switch Sync Service</string>
     <!-- This is the label a screenreader uses to inform the user they selected a label on the screen that includes the application version number -->
     <string name="app_version_description">Application version number</string>
 

--- a/app/src/test/java/mozilla/lockbox/presenter/SettingPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/SettingPresenterTest.kt
@@ -9,6 +9,7 @@ package mozilla.lockbox.presenter
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
 import mozilla.lockbox.action.AppWebPageAction
 import mozilla.lockbox.action.DialogAction
@@ -25,6 +26,7 @@ import mozilla.lockbox.adapter.ToggleSettingConfiguration
 import mozilla.lockbox.extensions.assertLastValue
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
+import mozilla.lockbox.store.AccountStore
 import mozilla.lockbox.store.FingerprintStore
 import mozilla.lockbox.store.SettingStore
 import org.junit.Assert
@@ -40,6 +42,7 @@ import org.robolectric.RobolectricTestRunner
 import org.mockito.Mockito.`when` as whenCalled
 
 @RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
 class SettingPresenterTest {
     class SettingViewFake : SettingView {
         var settingItem: List<SettingCellConfiguration>? = null
@@ -56,6 +59,7 @@ class SettingPresenterTest {
 
     private val unlockWithFingerprintStub = PublishSubject.create<Boolean>()
     private val sendUsageDataStub = PublishSubject.create<Boolean>()
+    private val useLocalServiceStub = PublishSubject.create<Boolean>()
     private val itemListSortOrderStub = PublishSubject.create<Setting.ItemListSort>()
     private val unlockWithFingerprintPendingAuthStub = PublishSubject.create<Boolean>()
     private val autoLockTimeStub = PublishSubject.create<Setting.AutoLockTime>()
@@ -63,6 +67,7 @@ class SettingPresenterTest {
 
     @Mock
     val settingStore = PowerMockito.mock(SettingStore::class.java)
+    val accountStore = PowerMockito.mock(AccountStore::class.java)
 
     private lateinit var testHelper: ListAdapterTestHelper
     private val view = SettingViewFake()
@@ -78,6 +83,7 @@ class SettingPresenterTest {
         whenCalled(settingStore.unlockWithFingerprint).thenReturn(unlockWithFingerprintStub)
         whenCalled(settingStore.unlockWithFingerprintPendingAuth).thenReturn(unlockWithFingerprintPendingAuthStub)
         whenCalled(settingStore.sendUsageData).thenReturn(sendUsageDataStub)
+        whenCalled(settingStore.useLocalService).thenReturn(useLocalServiceStub)
         whenCalled(settingStore.itemListSortOrder).thenReturn(itemListSortOrderStub)
         whenCalled(settingStore.onEnablingFingerprint).thenReturn(onEnablingFingerprintStub)
 
@@ -87,7 +93,9 @@ class SettingPresenterTest {
         testHelper = ListAdapterTestHelper()
         subject = SettingPresenter(
             view,
+            false,
             dispatcher,
+            accountStore,
             settingStore,
             fingerprintStore
         )

--- a/app/src/test/java/mozilla/lockbox/presenter/WelcomePresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/WelcomePresenterTest.kt
@@ -25,6 +25,7 @@ import org.mockito.Mockito
 class WelcomePresenterTest {
     class FakeWelcomeView : WelcomeView {
         var existingAccount: Boolean? = null
+        var chinaBuild: Boolean? = null
 
         override fun showExistingAccount(email: String) {
             existingAccount = true
@@ -32,6 +33,10 @@ class WelcomePresenterTest {
 
         override fun hideExistingAccount() {
             existingAccount = false
+        }
+
+        override fun hideSwitchService() {
+            chinaBuild = false
         }
 
         val learnMoreStub = PublishSubject.create<Unit>()
@@ -44,6 +49,10 @@ class WelcomePresenterTest {
         val getStartedExistingAcccountStub: PublishSubject<Unit> = PublishSubject.create<Unit>()
         override val getStartedAutomaticallyClicks: Observable<Unit>
             get() = getStartedExistingAcccountStub
+
+        val switchServiceStub: PublishSubject<Unit> = PublishSubject.create<Unit>()
+        override val switchServiceClicks: Observable<Unit>
+            get() = switchServiceStub
     }
 
     @Mock
@@ -58,7 +67,7 @@ class WelcomePresenterTest {
     val dispatcher = Dispatcher()
     val dispatcherObserver = TestObserver.create<Action>()
 
-    val subject = WelcomePresenter(view, dispatcher,
+    val subject = WelcomePresenter(view, false, dispatcher,
         accountStore = accountStore,
         fingerprintStore = fingerprintStore
     )


### PR DESCRIPTION
Fixes #1079 

## Testing and Review Notes

If a user is now set his/her phone as locale=zh_CN & language = Chinese, and the lockwise apk is not downloaded from Google play, there should be a way for the user to switch the service before login. After login, there should be no toggle button for switching service in settings.
Else there should be no "switch service" option, just like before.

## Screenshots or Videos
<img width="300" alt="图片" src="https://user-images.githubusercontent.com/33616048/69206113-c5c88f00-0b86-11ea-81ec-2e31086fbdb4.png"> <img width="300" alt="图片" src="https://user-images.githubusercontent.com/33616048/69206125-cfea8d80-0b86-11ea-8ef2-ca659533ced4.png">

## To Do

- The existed tests are all passed but I'm still working on the tests related to these new features

- The default value of local service/global service is not really runtime. It is set during app firstrun; if change the locale and language setting later, the default value won't change with the new settings.

