### PR TITLE
Introduce Glean SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,7 @@ plugins {
     id 'kotlin-android'
     id 'io.sentry.android.gradle'
     id 'jacoco'
+    id "com.jetbrains.python.envs" version "0.0.26"
 }
 
 android {
@@ -103,6 +104,7 @@ dependencies {
     implementation "org.mozilla.components:service-sync-logins:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:service-firefox-accounts:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:service-telemetry:${rootProject.ext.android_components_version}"
+    implementation "org.mozilla.components:service-glean:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-dataprotect:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-publicsuffixlist:${rootProject.ext.android_components_version}"
@@ -260,6 +262,11 @@ if (project.hasProperty("coverage")) {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions.allWarningsAsErrors = true
 }
+
+// Generate markdown docs for the collected metrics.
+ext.gleanGenerateMarkdownDocs = true
+ext.gleanDocsDirectory = "$rootDir/docs/glean"
+apply from: 'https://github.com/mozilla-mobile/android-components/raw/v' + rootProject.ext.android_components_version + '/components/service/glean/scripts/sdk_generator.gradle'
 
 // Internal, but stable and convenient.
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier

--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -100,7 +100,7 @@ open class LockboxApplication : Application() {
     }
 
     private fun injectContext() {
-        val contextStoreList: List<ContextStore> = listOf(
+        val contextStoreList: List<ContextStore> = listOfNotNull(
             FingerprintStore.shared,
             SettingStore.shared,
             SecurePreferences.shared,
@@ -108,7 +108,8 @@ open class LockboxApplication : Application() {
             NetworkStore.shared,
             TimingSupport.shared,
             AccountStore.shared,
-            if (FeatureFlags.USE_GLEAN) GleanTelemetryStore.shared else TelemetryStore.shared,
+            if (FeatureFlags.INCLUDE_DEPRECATED_TELEMETRY) TelemetryStore.shared else null,
+            GleanTelemetryStore.shared,
             SentryStore.shared,
             PublicSuffixSupport.shared
         )

--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -26,6 +26,7 @@ import mozilla.lockbox.store.ClipboardStore
 import mozilla.lockbox.store.ContextStore
 import mozilla.lockbox.store.DataStore
 import mozilla.lockbox.store.FingerprintStore
+import mozilla.lockbox.store.GleanTelemetryStore
 import mozilla.lockbox.store.LockedStore
 import mozilla.lockbox.store.NetworkStore
 import mozilla.lockbox.store.SentryStore
@@ -34,6 +35,7 @@ import mozilla.lockbox.store.TelemetryStore
 import mozilla.lockbox.support.AdjustSupport
 import mozilla.lockbox.support.TimingSupport
 import mozilla.lockbox.support.Constant
+import mozilla.lockbox.support.FeatureFlags
 import mozilla.lockbox.support.FxASyncDataStoreSupport
 import mozilla.lockbox.support.PublicSuffixSupport
 import mozilla.lockbox.support.SecurePreferences
@@ -106,7 +108,7 @@ open class LockboxApplication : Application() {
             NetworkStore.shared,
             TimingSupport.shared,
             AccountStore.shared,
-            TelemetryStore.shared,
+            if (FeatureFlags.USE_GLEAN) GleanTelemetryStore.shared else TelemetryStore.shared,
             SentryStore.shared,
             PublicSuffixSupport.shared
         )

--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -30,10 +30,13 @@ import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.store.AccountStore
 import mozilla.lockbox.store.AutofillStore
+import mozilla.lockbox.store.ContextStore
 import mozilla.lockbox.store.DataStore
+import mozilla.lockbox.store.GleanTelemetryStore
 import mozilla.lockbox.store.TelemetryStore
 import mozilla.lockbox.support.FxASyncDataStoreSupport
 import mozilla.lockbox.support.Constant
+import mozilla.lockbox.support.FeatureFlags
 import mozilla.lockbox.support.PublicSuffixSupport
 import mozilla.lockbox.support.SecurePreferences
 import mozilla.lockbox.support.asOptional
@@ -46,7 +49,6 @@ class LockboxAutofillService(
     private val dataStore: DataStore = DataStore.shared,
     private val securePreferences: SecurePreferences = SecurePreferences.shared,
     private val fxaSupport: FxASyncDataStoreSupport = FxASyncDataStoreSupport.shared,
-    private val telemetryStore: TelemetryStore = TelemetryStore.shared,
     private val autofillStore: AutofillStore = AutofillStore.shared,
     val dispatcher: Dispatcher = Dispatcher.shared
 ) : AutofillService() {
@@ -147,6 +149,8 @@ class LockboxAutofillService(
 
     private fun intializeService() {
         isRunning = true
+
+        val telemetryStore: ContextStore = if (FeatureFlags.USE_GLEAN) GleanTelemetryStore.shared else TelemetryStore.shared
 
         val contextInjectables = arrayOf(
             telemetryStore,

--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -30,9 +30,9 @@ import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.store.AccountStore
 import mozilla.lockbox.store.AutofillStore
-import mozilla.lockbox.store.ContextStore
 import mozilla.lockbox.store.DataStore
 import mozilla.lockbox.store.GleanTelemetryStore
+import mozilla.lockbox.store.SettingStore
 import mozilla.lockbox.store.TelemetryStore
 import mozilla.lockbox.support.FxASyncDataStoreSupport
 import mozilla.lockbox.support.Constant
@@ -47,8 +47,10 @@ import mozilla.lockbox.support.isDebug
 class LockboxAutofillService(
     private val accountStore: AccountStore = AccountStore.shared,
     private val dataStore: DataStore = DataStore.shared,
+    private val settingStore: SettingStore = SettingStore.shared,
     private val securePreferences: SecurePreferences = SecurePreferences.shared,
     private val fxaSupport: FxASyncDataStoreSupport = FxASyncDataStoreSupport.shared,
+    private val gleanTelemetryStore: GleanTelemetryStore = GleanTelemetryStore.shared,
     private val autofillStore: AutofillStore = AutofillStore.shared,
     val dispatcher: Dispatcher = Dispatcher.shared
 ) : AutofillService() {
@@ -150,10 +152,10 @@ class LockboxAutofillService(
     private fun intializeService() {
         isRunning = true
 
-        val telemetryStore: ContextStore = if (FeatureFlags.USE_GLEAN) GleanTelemetryStore.shared else TelemetryStore.shared
-
-        val contextInjectables = arrayOf(
-            telemetryStore,
+        val contextInjectables = listOfNotNull(
+            settingStore,
+            gleanTelemetryStore,
+            if (FeatureFlags.INCLUDE_DEPRECATED_TELEMETRY) TelemetryStore.shared else null,
             securePreferences,
             accountStore,
             fxaSupport

--- a/app/src/main/java/mozilla/lockbox/store/GleanTelemetryStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/GleanTelemetryStore.kt
@@ -1,0 +1,48 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.store
+
+import android.content.Context
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxkotlin.addTo
+import mozilla.components.service.glean.Glean
+import mozilla.components.service.glean.config.Configuration
+import mozilla.lockbox.BuildConfig
+
+open class GleanWrapper {
+    open var uploadEnabled: Boolean
+        get() = Glean.getUploadEnabled()
+        set(value) {
+            Glean.setUploadEnabled(value)
+        }
+
+    open fun initialize(context: Context, channel: String) {
+        Glean.initialize(context, Configuration(channel = channel))
+    }
+}
+
+class GleanTelemetryStore(
+    private val gleanWrapper: GleanWrapper = GleanWrapper(),
+    private val settingStore: SettingStore = SettingStore.shared
+) : ContextStore {
+
+    companion object {
+        val shared by lazy { GleanTelemetryStore() }
+    }
+
+    private val compositeDisposable = CompositeDisposable()
+
+    override fun injectContext(context: Context) {
+        gleanWrapper.initialize(context, BuildConfig.BUILD_TYPE)
+
+        settingStore.sendUsageData
+            .subscribe {
+                gleanWrapper.uploadEnabled = it
+            }
+            .addTo(compositeDisposable)
+    }
+}

--- a/app/src/main/java/mozilla/lockbox/store/GleanTelemetryStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/GleanTelemetryStore.kt
@@ -37,12 +37,11 @@ class GleanTelemetryStore(
     private val compositeDisposable = CompositeDisposable()
 
     override fun injectContext(context: Context) {
-        gleanWrapper.initialize(context, BuildConfig.BUILD_TYPE)
-
         settingStore.sendUsageData
             .subscribe {
                 gleanWrapper.uploadEnabled = it
             }
             .addTo(compositeDisposable)
+        gleanWrapper.initialize(context, BuildConfig.BUILD_TYPE)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/TelemetryStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/TelemetryStore.kt
@@ -12,6 +12,7 @@
 package mozilla.lockbox.store
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
@@ -91,7 +92,8 @@ open class TelemetryStore(
 
     internal val compositeDisposable = CompositeDisposable()
 
-    init {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun register() {
         dispatcher.register
             .filterByType(TelemetryAction::class.java)
             .subscribe {
@@ -108,6 +110,7 @@ open class TelemetryStore(
     }
 
     override fun injectContext(context: Context) {
+        register()
         wrapper.lateinitContext(context)
         settingStore
             .sendUsageData

--- a/app/src/main/java/mozilla/lockbox/support/FeatureFlags.kt
+++ b/app/src/main/java/mozilla/lockbox/support/FeatureFlags.kt
@@ -49,17 +49,18 @@ object FeatureFlags {
     }
 
     /**
-     * Use the Glean telemetry store.
+     * Include the legacy telemetry service. As part of our migration to the Glean, we will want
+     * to keep the legacy service running in parallel.
      *
-     * If false, the legacy telemetry-service is used.
-     * If true, the glean telemetry service is used.
+     * If true, the legacy telemetry-service is used.
+     * If false, the legacy telemetry-service is not.
      *
      * Either way, the user can opt out of this from the settings.
      */
-    val USE_GLEAN = when {
+    val INCLUDE_DEPRECATED_TELEMETRY = when {
         isDebug -> true
-        isTesting -> false
-        isRelease -> false
-        else -> false
+        isTesting -> true
+        isRelease -> true
+        else -> true
     }
 }

--- a/app/src/main/java/mozilla/lockbox/support/FeatureFlags.kt
+++ b/app/src/main/java/mozilla/lockbox/support/FeatureFlags.kt
@@ -47,4 +47,19 @@ object FeatureFlags {
         isRelease -> true
         else -> true
     }
+
+    /**
+     * Use the Glean telemetry store.
+     *
+     * If false, the legacy telemetry-service is used.
+     * If true, the glean telemetry service is used.
+     *
+     * Either way, the user can opt out of this from the settings.
+     */
+    val USE_GLEAN = when {
+        isDebug -> true
+        isTesting -> false
+        isRelease -> false
+        else -> false
+    }
 }

--- a/app/src/test/java/mozilla/lockbox/store/GleanTelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/GleanTelemetryStoreTest.kt
@@ -1,0 +1,68 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.store
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.reactivex.subjects.ReplaySubject
+import mozilla.lockbox.flux.Dispatcher
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.powermock.api.mockito.PowerMockito.`when`
+import org.powermock.api.mockito.PowerMockito.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(packageName = "mozilla.lockbox")
+class GleanTelemetryStoreTest {
+    @Mock
+    private val settingStore = mock(SettingStore::class.java)
+    private val sendUsageDataStub = ReplaySubject.createWithSize<Boolean>(1)
+
+    @Mock
+    val telemetryWrapper = object : GleanWrapper() {
+        override var uploadEnabled = false
+        var channel: String = ""
+        override fun initialize(context: Context, channel: String) {
+            this.channel = channel
+        }
+    }
+
+    val dispatcher = Dispatcher()
+
+    val context: Context = ApplicationProvider.getApplicationContext()
+
+    lateinit var subject: GleanTelemetryStore
+
+    @Before
+    fun setUp() {
+        sendUsageDataStub.onNext(true)
+        `when`(settingStore.sendUsageData).thenReturn(sendUsageDataStub)
+        subject = GleanTelemetryStore(telemetryWrapper, settingStore)
+    }
+
+    @Test
+    fun `when context is injected, verify glean is initialized`() {
+        subject.injectContext(context)
+        assertTrue(telemetryWrapper.uploadEnabled)
+    }
+
+    @Test
+    fun `when sendUsageData is toggled, verify glean is turned off`() {
+        subject.injectContext(context)
+        sendUsageDataStub.onNext(false)
+        assertFalse(telemetryWrapper.uploadEnabled)
+
+        sendUsageDataStub.onNext(true)
+        assertTrue(telemetryWrapper.uploadEnabled)
+    }
+}

--- a/app/src/test/java/mozilla/lockbox/store/GleanTelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/GleanTelemetryStoreTest.kt
@@ -7,14 +7,21 @@
 package mozilla.lockbox.store
 
 import android.content.Context
+import android.content.SharedPreferences
+import android.view.autofill.AutofillManager
 import androidx.test.core.app.ApplicationProvider
 import io.reactivex.subjects.ReplaySubject
 import mozilla.lockbox.flux.Dispatcher
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
 import org.powermock.api.mockito.PowerMockito.`when`
 import org.powermock.api.mockito.PowerMockito.mock
@@ -64,5 +71,66 @@ class GleanTelemetryStoreTest {
 
         sendUsageDataStub.onNext(true)
         assertTrue(telemetryWrapper.uploadEnabled)
+    }
+
+    @Test
+    fun `ensure upload enabled is called before initialize`() {
+        // We spend quite a lot of effort here to convince ourselves that the user's preference
+        // for sending usage data is respected before initializing glean.
+        // If this test fails, then either we're losing ping data or we're uploading ping data
+        // when the user has explicitly said not to.
+
+        // mock all this out for the setting store, so we can use the Rx machinery it uses.
+        val context = mock(Context::class.java)
+        `when`(context.getSystemService(eq(AutofillManager::class.java))).thenReturn(mock(AutofillManager::class.java))
+        val prefs = mock(SharedPreferences::class.java)
+        `when`(prefs.contains(eq(SettingStore.Keys.DEVICE_SECURITY_PRESENT))).thenReturn(true)
+        `when`(prefs.contains(eq(SettingStore.Keys.SEND_USAGE_DATA))).thenReturn(true)
+        `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(prefs)
+
+        val fingerprintStore = mock(FingerprintStore::class.java)
+        `when`(fingerprintStore.isDeviceSecure).thenReturn(true)
+
+        class DummyGleanWrapper : GleanWrapper() {
+            var initializationOrder = arrayListOf<String>()
+
+            override var uploadEnabled: Boolean = false
+                set(value) {
+                    initializationOrder.add("uploadEnabled")
+                    field = value
+                }
+
+            override fun initialize(context: Context, channel: String) {
+                initializationOrder.add("initialize")
+            }
+        }
+
+        fun testWithPref(enabled: Boolean) {
+            `when`(
+                prefs.getBoolean(
+                    eq(SettingStore.Keys.SEND_USAGE_DATA),
+                    anyBoolean()
+                )
+            ).thenReturn(enabled)
+
+            val telemetryWrapper = DummyGleanWrapper()
+
+            val settingStore = SettingStore(fingerprintStore = fingerprintStore)
+            val gleanTelemetryStore = GleanTelemetryStore(telemetryWrapper, settingStore)
+
+            // These should appear in the same order as they do in `injectContext` in
+            // `LockwiseApplication` and `initializeService` in `LockwiseAutofillService`.
+            settingStore.injectContext(context)
+            gleanTelemetryStore.injectContext(context)
+
+            assertEquals(
+                "uploadEnabled, initialize",
+                telemetryWrapper.initializationOrder.joinToString(", ")
+            )
+            assertEquals(enabled, telemetryWrapper.uploadEnabled)
+        }
+
+        testWithPref(false)
+        testWithPref(true)
     }
 }

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -88,6 +88,7 @@ class TelemetryStoreTest : DisposingTest() {
         val uploadObserver = createTestObserver<Int>()
         wrapper.eventsSubject.subscribe(eventsObserver)
         wrapper.uploadSubject.subscribe(uploadObserver)
+        subject.register()
 
         var action: TelemetryAction = LifecycleAction.Foreground
         dispatcher.dispatch(action)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -5,8 +5,9 @@ _Last Updated: Feb 4, 2019_
 <!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Analysis](#analysis)
-- [Collection](#collection)
+- [Collection](#collection-legacy)
 - [List of Implemented Events](#list-of-implemented-events)
+- [Mozilla Glean SDK](#mozilla-glean-sdk)
 - [Adjust SDK](#adjust-sdk)
 - [References](#references)
 
@@ -50,7 +51,7 @@ In service to validating the above hypothesis, we plan on answering these specif
 
 In addition to answering the above questions that directly concern actions in the app, we will also analyze telemetry emitted from the password manager that exists in the the Firefox desktop browser. These analyses will primarily examine whether users of Lockwise start active curation of their credentials in the desktop browser (Lockwise users will not be able to edit credentials directly from the app).
 
-## Collection
+## Collection (legacy)
 
 *Note: There is currently a new Mozilla mobile telemetry SDK under development, however it will not ship prior to the Lockwise for Android app. Once the new SDK ships we will evaluate whether or not to tear out the old implementation and replace it with the new SDK.*
 
@@ -179,6 +180,15 @@ https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/c
 	* `value`: null
 	* `extras`: null
 
+## Mozilla Glean SDK
+
+Lockwise for Android uses the [Glean SDK](https://mozilla.github.io/glean/book/index.html) to collect telemetry. The Glean SDK provides a handful of [pings and metrics out of the box](https://mozilla.github.io/glean/book/user/pings/index.html). The data review for using the Glean SDK is available at [this link](TODO).
+
+Lockwise for Android also uses the following Glean-enabled components of [Android Components](https://github.com/mozilla-mobile/android-components/), which are sending telemetry:
+
+|Name|Description|Collected metrics|Data review|
+|---|---|---|---|
+|[Firefox accounts](https://github.com/mozilla-mobile/android-components/tree/master/components/service/firefox-accounts)|A library for integrating with Firefox Accounts.| [docs](https://github.com/mozilla-mobile/android-components/blob/master/components/support/sync-telemetry/docs/metrics.md)| [review](TODO) |
 
 ## Adjust SDK
 
@@ -186,7 +196,9 @@ The app also includes a version of the [adjust SDK](https://github.com/adjust/an
 
 ## References
 
-[Library used to collect and send telemetry on Android](https://github.com/mozilla-mobile/android-components/blob/master/components/service/telemetry/README.md)
+[Glean SDK repository, used to collect and send telemetry](https://github.com/mozilla/glean/)
+
+[Legacy library used to collect and send telemetry on Android](https://github.com/mozilla-mobile/android-components/blob/master/components/service/telemetry/README.md)
 
 [Description of the "Core" ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/core-ping.html)
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -182,13 +182,13 @@ https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/c
 
 ## Mozilla Glean SDK
 
-Lockwise for Android uses the [Glean SDK](https://mozilla.github.io/glean/book/index.html) to collect telemetry. The Glean SDK provides a handful of [pings and metrics out of the box](https://mozilla.github.io/glean/book/user/pings/index.html). The data review for using the Glean SDK is available at [this link](TODO).
+Lockwise for Android uses the [Glean SDK](https://mozilla.github.io/glean/book/index.html) to collect telemetry. The Glean SDK provides a handful of [pings and metrics out of the box](https://mozilla.github.io/glean/book/user/pings/index.html). The data review for using the Glean SDK is available at [this link](https://github.com/mozilla-lockwise/lockwise-android/pull/1085#issuecomment-558767676).
 
 Lockwise for Android also uses the following Glean-enabled components of [Android Components](https://github.com/mozilla-mobile/android-components/), which are sending telemetry:
 
 |Name|Description|Collected metrics|Data review|
 |---|---|---|---|
-|[Firefox accounts](https://github.com/mozilla-mobile/android-components/tree/master/components/service/firefox-accounts)|A library for integrating with Firefox Accounts.| [docs](https://github.com/mozilla-mobile/android-components/blob/master/components/support/sync-telemetry/docs/metrics.md)| [review](TODO) |
+|[Firefox accounts](https://github.com/mozilla-mobile/android-components/tree/master/components/service/firefox-accounts)|A library for integrating with Firefox Accounts.| [docs](https://github.com/mozilla-mobile/android-components/blob/master/components/support/sync-telemetry/docs/metrics.md)| [review](https://github.com/mozilla-lockwise/lockwise-android/pull/1085#issuecomment-558767676) |
 
 ## Adjust SDK
 


### PR DESCRIPTION
This is the first part of #127.

This PR adds the Glean SDK as a dependency and enables it. It additionally adds basic documentation in the docs/metrics.md.

It replaces #1073.

It puts Glean in a `GleanTelemetryStore` and hooks it up to the setting for toggling `sendUsageData`.

It also puts this behind a `FeatureFlag` so we can still release without landing the rest of the Glean work.