### PR TITLE
Autofill: Autopopulate the fields after search/authentication.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/autofill/FillResponseBuilder.kt
+++ b/app/src/main/java/mozilla/lockbox/autofill/FillResponseBuilder.kt
@@ -103,6 +103,10 @@ open class FillResponseBuilder(
         return builder.build()
     }
 
+    open fun buildSelectedDatasetResponse(context: Context, credential: ServerPassword): Dataset {
+        return serverPasswordToDataset(context, credential)
+    }
+
     private fun setupSaveInfo(builder: FillResponse.Builder) {
         if (FeatureFlags.AUTOFILL_CAPTURE) {
             builder.setSaveInfo(buildSaveInfo())

--- a/app/src/main/java/mozilla/lockbox/presenter/AutofillRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AutofillRoutePresenter.kt
@@ -3,7 +3,7 @@ package mozilla.lockbox.presenter
 import android.app.Activity
 import android.content.Intent
 import android.os.Build
-import android.service.autofill.FillResponse
+import android.os.Parcelable
 import android.view.autofill.AutofillManager
 import androidx.annotation.IdRes
 import androidx.annotation.RequiresApi
@@ -129,7 +129,10 @@ open class AutofillRoutePresenter(
     }
 
     private fun finishResponse(passwords: List<ServerPassword>) {
-        val response = responseBuilder.buildFilteredFillResponse(activity, passwords)
+        val response = if (passwords.size == 1)
+                responseBuilder.buildSelectedDatasetResponse(activity, passwords.first())
+            else
+                responseBuilder.buildFilteredFillResponse(activity, passwords)
         response?.let { setFillResponseAndFinish(it) } ?: cancelAndFinish()
     }
 
@@ -138,7 +141,7 @@ open class AutofillRoutePresenter(
         activity.finish()
     }
 
-    private fun setFillResponseAndFinish(fillResponse: FillResponse) {
+    private fun setFillResponseAndFinish(fillResponse: Parcelable) {
         val results = Intent().putExtra(AutofillManager.EXTRA_AUTHENTICATION_RESULT, fillResponse)
         activity.setResult(Activity.RESULT_OK, results)
         activity.finish()

--- a/app/src/main/java/mozilla/lockbox/presenter/AutofillRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AutofillRoutePresenter.kt
@@ -129,10 +129,11 @@ open class AutofillRoutePresenter(
     }
 
     private fun finishResponse(passwords: List<ServerPassword>) {
-        val response = if (passwords.size == 1)
-                responseBuilder.buildSelectedDatasetResponse(activity, passwords.first())
-            else
-                responseBuilder.buildFilteredFillResponse(activity, passwords)
+        val response = if (passwords.size == 1) {
+            responseBuilder.buildSelectedDatasetResponse(activity, passwords.first())
+        } else {
+            responseBuilder.buildFilteredFillResponse(activity, passwords)
+        }
         response?.let { setFillResponseAndFinish(it) } ?: cancelAndFinish()
     }
 

--- a/app/src/test/java/mozilla/lockbox/presenter/AutofillRoutePresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AutofillRoutePresenterTest.kt
@@ -10,6 +10,7 @@ import android.app.Activity
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
+import android.service.autofill.Dataset
 import android.service.autofill.FillResponse
 import android.view.autofill.AutofillManager
 import androidx.activity.OnBackPressedDispatcher
@@ -125,9 +126,14 @@ class AutofillRoutePresenterTest {
         @Mock
         val filteredFillResponse: FillResponse = mock(FillResponse::class.java)
 
+        @Mock
+        val singleDataset: Dataset = mock(Dataset::class.java)
+
         val asyncFilterStub = PublishSubject.create<List<ServerPassword>>()
 
         var filteredFillResponsePasswordsArgument: List<ServerPassword>? = null
+
+        var datasetResponse: Dataset? = null
 
         override fun buildFilteredFillResponse(
             context: Context,
@@ -135,6 +141,15 @@ class AutofillRoutePresenterTest {
         ): FillResponse? {
             filteredFillResponsePasswordsArgument = filteredPasswords
             return filteredFillResponse
+        }
+
+        override fun buildSelectedDatasetResponse(
+            context: Context,
+            credential: ServerPassword
+        ): Dataset {
+            filteredFillResponsePasswordsArgument = listOf(credential)
+            datasetResponse = singleDataset
+            return singleDataset
         }
 
         override fun asyncFilter(
@@ -283,10 +298,11 @@ class AutofillRoutePresenterTest {
         autofillStore.autofillActionStub.onNext(AutofillAction.Complete(login))
 
         Assert.assertEquals(listOf(login), responseBuilder.filteredFillResponsePasswordsArgument)
+        assertEquals(responseBuilder.singleDataset, responseBuilder.singleDataset)
 
         verify(activity).setResult(eq(Activity.RESULT_OK), any<Intent>())
         verify(activity).finish()
-        verify(intent).putExtra(AutofillManager.EXTRA_AUTHENTICATION_RESULT, responseBuilder.filteredFillResponse)
+        verify(intent).putExtra(AutofillManager.EXTRA_AUTHENTICATION_RESULT, responseBuilder.singleDataset)
     }
 
     @Test


### PR DESCRIPTION
Fixes #1008.

This performs autopopulate when exactly one dataset is selected following a search (the usual case) or
found during authentication.