### PR TITLE
Metadata cleanups for datastore and autofill.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.os.CancellationSignal
 import android.service.autofill.AutofillService
 import android.service.autofill.FillCallback
+import android.service.autofill.FillEventHistory
 import android.service.autofill.FillRequest
 import android.service.autofill.SaveCallback
 import android.service.autofill.SaveRequest
@@ -72,10 +73,12 @@ class LockboxAutofillService(
     }
 
     override fun onFillRequest(request: FillRequest, cancellationSignal: CancellationSignal, callback: FillCallback) {
+        touchRecentlyUsedDatasets()
+
         val structure = request.fillContexts.last().structure
         val activityPackageName = structure.activityComponent.packageName
         if (this.packageName == activityPackageName) {
-            callback.onSuccess(null)
+            callback.onFailure(null)
             return
         }
 
@@ -87,11 +90,11 @@ class LockboxAutofillService(
                 val xml = structure.getWindowNodeAt(0).rootViewNode.dump()
                 log.debug("Autofilling $activityPackageName failed for:\n$xml")
             }
-            callback.onSuccess(null)
+            callback.onFailure(null)
             return
         }
 
-        intializeService()
+        initializeService()
 
         val builder = FillResponseBuilder(parsedStructure)
 
@@ -149,7 +152,26 @@ class LockboxAutofillService(
             .addTo(compositeDisposable)
     }
 
-    private fun intializeService() {
+    private fun touchRecentlyUsedDatasets() {
+        val selectedDatasetIds = fillEventHistory?.events?.let { list ->
+            list.filter { it.type == FillEventHistory.Event.TYPE_DATASET_SELECTED }
+                .mapNotNull { it.datasetId }
+        }
+        if (selectedDatasetIds?.isEmpty() != false) {
+            return
+        }
+        initializeService()
+        selectedDatasetIds
+            .map { DataStoreAction.AutofillTouch(it) }
+            .forEach(dispatcher::dispatch)
+    }
+
+    private fun initializeService() {
+        if (isRunning) {
+            // we might have already been called when logging
+            // a previously chosen dataset.
+            return
+        }
         isRunning = true
 
         val contextInjectables = listOfNotNull(

--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -216,12 +216,13 @@ class LockboxAutofillService(
         pslSuffix.take(1)
             .map { suffix ->
                 val domain = "https://${suffix.fullDomain}"
+                val webDomain = parsedStructure.webDomain?.let { "https://$it" }
                 ServerPassword(
                     id = emptyId,
                     hostname = domain,
                     username = capturedUsername,
                     password = capturedPassword,
-                    formSubmitURL = parsedStructure.webDomain ?: domain
+                    formSubmitURL = webDomain ?: domain
                 )
             }
             .doOnComplete {

--- a/app/src/main/java/mozilla/lockbox/action/DataStoreAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DataStoreAction.kt
@@ -99,7 +99,10 @@ sealed class DataStoreAction(
     /**
      * Dispatched when the user edits or saves an entry.
      */
-    data class UpdateItemDetail(val item: ServerPassword)
+    data class UpdateItemDetail(
+        val previous: ServerPassword,
+        val next: ServerPassword
+    )
         : DataStoreAction(
             TelemetryEventMethod.edit,
             TelemetryEventObject.update_credential

--- a/app/src/main/java/mozilla/lockbox/action/DataStoreAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DataStoreAction.kt
@@ -71,6 +71,15 @@ sealed class DataStoreAction(
     )
 
     /**
+     * Dispatched when the user accesses a credential in the context of autofill.
+     */
+    data class AutofillTouch(val id: String) : DataStoreAction(
+        TelemetryEventMethod.touch,
+        TelemetryEventObject.datastore,
+        "ID: $id"
+    )
+
+    /**
      * Dispatched when the user logs in or starts the app with a logged in state.
      */
     data class UpdateSyncCredentials(val syncCredentials: SyncCredentials) : DataStoreAction(

--- a/app/src/main/java/mozilla/lockbox/action/ItemDetailAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/ItemDetailAction.kt
@@ -14,7 +14,7 @@ sealed class ItemDetailAction(
 ) : TelemetryAction {
     data class SetPasswordVisibility(val visible: Boolean) :
         ItemDetailAction(TelemetryEventMethod.tap, TelemetryEventObject.reveal_password)
-    data class SaveChanges(val item: ServerPassword) :
+    data class SaveChanges(val previous: ServerPassword, val next: ServerPassword) :
         ItemDetailAction(TelemetryEventMethod.tap, TelemetryEventObject.update_credential)
     data class EndEditing(val itemId: String) :
         ItemDetailAction(TelemetryEventMethod.tap, TelemetryEventObject.back)

--- a/app/src/main/java/mozilla/lockbox/autofill/FillResponseBuilder.kt
+++ b/app/src/main/java/mozilla/lockbox/autofill/FillResponseBuilder.kt
@@ -122,6 +122,8 @@ open class FillResponseBuilder(
         val title = titleFromHostname(credential.hostname)
         val username = credential.username ?: context.getString(R.string.no_username)
 
+        datasetBuilder.setId(credential.id)
+
         parsedStructure.usernameId?.let { id ->
             val presentation = RemoteViews(context.packageName, R.layout.autofill_item)
                 .apply {

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -172,8 +172,10 @@ class EditItemPresenter(
             .map {
                 // When there's something changed, then save them,
                 // otherwise, go back to the item detail screen.
-                credentialsToSave?.let { ItemDetailAction.SaveChanges(it) }
-                    ?: ItemDetailAction.EndEditing(itemId)
+                if (credentialsAtStart != null && credentialsToSave != null)
+                    ItemDetailAction.SaveChanges(credentialsAtStart!!, credentialsToSave!!)
+                else
+                    ItemDetailAction.EndEditing(itemId)
             }
             .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)

--- a/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
@@ -49,7 +49,7 @@ class ItemDetailStore(
             .subscribe { action ->
                 when (action) {
                     is ItemDetailAction.SetPasswordVisibility -> _passwordVisible.onNext(action.visible)
-                    is ItemDetailAction.SaveChanges -> saveItem(action.item)
+                    is ItemDetailAction.SaveChanges -> saveItem(action.previous, action.next)
                     is ItemDetailAction.EndEditing -> stopEditing()
                 }
             }
@@ -61,8 +61,8 @@ class ItemDetailStore(
         _isEditing.onNext(true)
     }
 
-    private fun saveItem(item: ServerPassword) {
-        dispatcher.dispatch(DataStoreAction.UpdateItemDetail(item))
+    private fun saveItem(previous: ServerPassword, next: ServerPassword) {
+        dispatcher.dispatch(DataStoreAction.UpdateItemDetail(previous, next))
         stopEditing()
     }
 

--- a/app/src/main/java/mozilla/lockbox/support/TimingSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/TimingSupport.kt
@@ -36,6 +36,9 @@ open class TimingSupport(
     open val shouldSync: Boolean
         get() = syncCurrentlyRequired()
 
+    val currentTimeMillis: Long
+        get() = systemTimingSupport.currentTimeMillis
+
     override fun injectContext(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
     }

--- a/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
@@ -281,7 +281,7 @@ class EditItemPresenterTest {
 
         dispatcherObserver.assertValueSequence(
             listOf(
-                ItemDetailAction.SaveChanges(fakeCredential.copy(username = "all-change"))
+                ItemDetailAction.SaveChanges(fakeCredential, fakeCredential.copy(username = "all-change"))
             )
         )
     }

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -117,7 +117,6 @@ class DataStoreTest : DisposingTest() {
         val change2 = original.copy(username = "newuser")
         val fixup2 = subject.fixupMutationMetadata(original, change2)
         assertEquals(change2.timePasswordChanged, fixup2.timePasswordChanged)
-
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -30,12 +30,14 @@ import mozilla.lockbox.support.asOptional
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.atLeastOnce
 import org.mockito.Mockito.clearInvocations
 import org.mockito.Mockito.never
@@ -66,6 +68,8 @@ class DataStoreTest : DisposingTest() {
         PowerMockito.whenNew(TimingSupport::class.java).withAnyArguments().thenReturn(timingSupport)
         dispatcher.register.subscribe(dispatcherObserver)
 
+        `when`(timingSupport.currentTimeMillis).thenReturn(System.currentTimeMillis())
+
         subject = DataStore(dispatcher, support, timingSupport, lifecycleStore)
     }
 
@@ -84,7 +88,7 @@ class DataStoreTest : DisposingTest() {
         val item = listIterator.next()[0]
         val newHostname = "https://ilovecats.com"
 
-        val updatedItem = ServerPassword(
+        val originalItem = ServerPassword(
             id = item.id,
             hostname = newHostname,
             username = item.username,
@@ -93,10 +97,27 @@ class DataStoreTest : DisposingTest() {
             formSubmitURL = item.formSubmitURL
         )
 
-        dispatcher.dispatch(DataStoreAction.UpdateItemDetail(updatedItem))
+        val updatedItem = originalItem.copy(password = "new password")
+
+        dispatcher.dispatch(DataStoreAction.UpdateItemDetail(originalItem, updatedItem))
 
         // check if the list is updated
         dispatcherObserver.assertValueAt(1, DataStoreAction.ListUpdate)
+    }
+
+    @Test
+    fun `test fixupMutationMetadata`() {
+        val original = ServerPassword(id = "id", hostname = "hostname.com", username = "username", password = "password")
+        val change1 = original.copy(password = "newpassword")
+        assertEquals(0, change1.timePasswordChanged)
+
+        val fixup1 = subject.fixupMutationMetadata(original, change1)
+        assertNotEquals(change1.timePasswordChanged, fixup1.timePasswordChanged)
+
+        val change2 = original.copy(username = "newuser")
+        val fixup2 = subject.fixupMutationMetadata(original, change2)
+        assertEquals(change2.timePasswordChanged, fixup2.timePasswordChanged)
+
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/store/ItemDetailStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/ItemDetailStoreTest.kt
@@ -87,17 +87,19 @@ class ItemDetailStoreTest : DisposingTest() {
         val observer = createTestObserver<ServerPassword>()
         dispatcher.register
             .filterByType(DataStoreAction.UpdateItemDetail::class.java)
-            .map { it.item }
+            .map { it.next }
             .subscribe(observer)
 
         val itemId = "id"
-        val item = ServerPassword(id = itemId,
+        val original = ServerPassword(id = itemId,
             hostname = "hostname.com",
             password = "password"
         )
 
-        dispatcher.dispatch(ItemDetailAction.SaveChanges(item))
+        val mutated = original.copy(password = "password1")
 
-        observer.assertLastValue(item)
+        dispatcher.dispatch(ItemDetailAction.SaveChanges(original, mutated))
+
+        observer.assertLastValue(mutated)
     }
 }


### PR DESCRIPTION
Fixes #1064.

This PR does a number of related things, each too small for their own PR:

 * Detect which credential the user selected during autofill send a touch to the data store.
 * On touch update the list, so that the Item list when ranked by recency is updated.
 * Add a change to the updateItem method to allow password changes to be detected, and the `timePasswordChanged` field to be updated.
 * On capture from autofill, the item list is updated, so new credentials show up immediately.