### PR TITLE
Fixes #1101 - Allow access to unlock button in forced landscape devices

### DIFF
--- a/app/src/main/res/layout/fragment_onboarding_confirmation.xml
+++ b/app/src/main/res/layout/fragment_onboarding_confirmation.xml
@@ -4,8 +4,12 @@
   ~  License, v. 2.0. If a copy of the MPL was not distributed with this
   ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
-<LinearLayout
+<ScrollView
         xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+<LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -96,3 +100,4 @@
     />
 
 </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_welcome.xml
+++ b/app/src/main/res/layout/fragment_welcome.xml
@@ -3,136 +3,140 @@
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
-
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/welcome_fragment"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:theme="@style/WelcomeScreen"
-    >
-
-    <include
-        android:id="@+id/include"
-        layout="@layout/include_welcome" />
-
-    <ImageView
-        android:id="@+id/lockwiseIcon"
-        android:layout_width="@dimen/logo_size"
-        android:layout_height="@dimen/logo_size"
-        android:background="@null"
-        android:src="@drawable/ic_lockwise_glyph"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="@dimen/logo_top_margin"
-        android:contentDescription="@string/app_name"
-    />
-
-    <ImageView
-        android:id="@+id/lockwiseTitle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@null"
-        android:src="@drawable/ic_title"
-        android:layout_marginTop="12dp"
-        app:layout_constraintTop_toBottomOf="@id/lockwiseIcon"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:contentDescription="@string/app_name"
-    />
-
-    <TextView
-        android:id="@+id/tagline"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="15sp"
-        android:fontFamily="sans-serif"
-        android:textStyle="normal"
-        android:textColor="@color/text_ink"
-        android:letterSpacing="-0.01"
-        android:background="@android:color/transparent"
-        android:text="@string/app_tagline"
-        app:layout_constraintTop_toBottomOf="@id/lockwiseTitle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="10dp"
-    />
-
-    <LinearLayout
+<ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:orientation="vertical"
-        android:layout_marginTop="40dp"
-        app:layout_constraintTop_toBottomOf="@id/tagline"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:background="@color/background_white">
+        android:layout_height="match_parent">
 
-        <Button
-            android:id="@+id/buttonGetStarted"
-            android:layout_width="220dp"
-            android:layout_height="36dp"
-            android:layout_marginBottom="8dp"
-            android:background="@drawable/button_pressed_violet"
-            android:letterSpacing="0.09"
-            android:lineSpacingExtra="2sp"
-            android:text="@string/welcome_start_btn"
-            android:textColor="@color/text_white"
-            android:textStyle="normal"
-            android:layout_gravity="center"
-            android:visibility="gone"
-        />
-
-        <Button
-            android:id="@+id/buttonGetStartedManually"
-            android:layout_width="180dp"
-            android:layout_height="36dp"
-            android:layout_marginBottom="8dp"
-            android:background="@drawable/button_pressed_violet"
-            android:letterSpacing="0.09"
-            android:lineSpacingExtra="2sp"
-            android:text="@string/welcome_start_btn"
-            android:textColor="@color/text_white"
-            android:textStyle="normal"
-            android:layout_gravity="center"
-            android:visibility="gone"
-        />
-
-        <TextView
-            android:id="@+id/textViewInstructions"
+    <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/welcome_fragment"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:layout_marginStart="55dp"
-            android:layout_marginEnd="55dp"
-            android:paddingStart="15dp"
-            android:paddingEnd="15dp"
-            android:text="@string/welcome_instructions"
-            android:textColor="@color/text_ink"
-            android:background="@android:color/transparent"
-            android:lineSpacingExtra="3.5sp"
-            android:textSize="13sp"
-            android:textAlignment="center"
-            android:gravity="center_horizontal"
-        />
+            android:layout_height="match_parent"
+            android:theme="@style/WelcomeScreen"
+            >
+
+        <include
+                android:id="@+id/include"
+                layout="@layout/include_welcome" />
+
+        <ImageView
+                android:id="@+id/lockwiseIcon"
+                android:layout_width="@dimen/logo_size"
+                android:layout_height="@dimen/logo_size"
+                android:background="@null"
+                android:src="@drawable/ic_lockwise_glyph"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:layout_marginTop="@dimen/logo_top_margin"
+                android:contentDescription="@string/app_name"
+                />
+
+        <ImageView
+                android:id="@+id/lockwiseTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@null"
+                android:src="@drawable/ic_title"
+                android:layout_marginTop="12dp"
+                app:layout_constraintTop_toBottomOf="@id/lockwiseIcon"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:contentDescription="@string/app_name"
+                />
 
         <TextView
-            android:id="@+id/textViewLearnMore"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:text="@string/welcome_learn_more_btn"
-            android:textStyle="bold"
-            android:textAllCaps="true"
-            android:background="@android:color/transparent"
-            android:textColor="@color/link_pressed"
-            android:textSize="12sp"
-            android:textAlignment="center"
-            android:letterSpacing="0.04"
-            android:layout_gravity="center"
-        />
-    </LinearLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+                android:id="@+id/tagline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="15sp"
+                android:fontFamily="sans-serif"
+                android:textStyle="normal"
+                android:textColor="@color/text_ink"
+                android:letterSpacing="-0.01"
+                android:background="@android:color/transparent"
+                android:text="@string/app_tagline"
+                app:layout_constraintTop_toBottomOf="@id/lockwiseTitle"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:layout_marginTop="10dp"
+                />
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:orientation="vertical"
+                android:layout_marginTop="40dp"
+                app:layout_constraintTop_toBottomOf="@id/tagline"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:background="@color/background_white">
+
+            <Button
+                    android:id="@+id/buttonGetStarted"
+                    android:layout_width="220dp"
+                    android:layout_height="36dp"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/button_pressed_violet"
+                    android:letterSpacing="0.09"
+                    android:lineSpacingExtra="2sp"
+                    android:text="@string/welcome_start_btn"
+                    android:textColor="@color/text_white"
+                    android:textStyle="normal"
+                    android:layout_gravity="center"
+                    android:visibility="gone"
+                    />
+
+            <Button
+                    android:id="@+id/buttonGetStartedManually"
+                    android:layout_width="180dp"
+                    android:layout_height="36dp"
+                    android:layout_marginBottom="8dp"
+                    android:background="@drawable/button_pressed_violet"
+                    android:letterSpacing="0.09"
+                    android:lineSpacingExtra="2sp"
+                    android:text="@string/welcome_start_btn"
+                    android:textColor="@color/text_white"
+                    android:textStyle="normal"
+                    android:layout_gravity="center"
+                    android:visibility="gone"
+                    />
+
+            <TextView
+                    android:id="@+id/textViewInstructions"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:layout_marginStart="55dp"
+                    android:layout_marginEnd="55dp"
+                    android:paddingStart="15dp"
+                    android:paddingEnd="15dp"
+                    android:text="@string/welcome_instructions"
+                    android:textColor="@color/text_ink"
+                    android:background="@android:color/transparent"
+                    android:lineSpacingExtra="3.5sp"
+                    android:textSize="13sp"
+                    android:textAlignment="center"
+                    android:gravity="center_horizontal"
+                    />
+
+            <TextView
+                    android:id="@+id/textViewLearnMore"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="@string/welcome_learn_more_btn"
+                    android:textStyle="bold"
+                    android:textAllCaps="true"
+                    android:background="@android:color/transparent"
+                    android:textColor="@color/link_pressed"
+                    android:textSize="12sp"
+                    android:textAlignment="center"
+                    android:letterSpacing="0.04"
+                    android:layout_gravity="center"
+                    />
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION

Fixes #1101 

## Testing and Review Notes

Tested using 5X emulator in android studio with resolution changed to force a landscape device. User is able to scroll down to the unlock / get started button and use the app

## Screenshots or Videos
![ezgif-3-cbdf700d0e80](https://user-images.githubusercontent.com/35984346/70357506-13aaeb80-1845-11ea-9590-f0ac1c26a57d.gif)

_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests (N/A)
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
