### PR TITLE
Fixup autofill footer in dark mode.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/DisplayItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/DisplayItemPresenter.kt
@@ -138,10 +138,12 @@ class DisplayItemPresenter(
             .addTo(compositeDisposable)
 
         networkStore.isConnected
+            .observeOn(mainThread())
             .subscribe(view::handleNetworkError)
             .addTo(compositeDisposable)
 
         itemDetailStore.isPasswordVisible
+            .observeOn(mainThread())
             .subscribe { view.isPasswordVisible = it }
             .addTo(compositeDisposable)
 

--- a/app/src/main/res/layout-v26/autofill_cta_presentation.xml
+++ b/app/src/main/res/layout-v26/autofill_cta_presentation.xml
@@ -12,6 +12,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme"
+        android:background="@color/background_white"
 >
     <TextView
             android:layout_width="225dp"

--- a/app/src/main/res/layout-v26/autofill_cta_presentation.xml
+++ b/app/src/main/res/layout-v26/autofill_cta_presentation.xml
@@ -11,9 +11,8 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:theme="@style/AppTheme"
-        android:background="@color/background_white"
->
+        style="@style/AutofillRemoteViewSyle">
+
     <TextView
             android:layout_width="225dp"
             android:layout_height="56dp"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -291,4 +291,8 @@
     <style name="NoConnectivityWarning">
         <item name="android:background">@color/color_primary_dark</item>
     </style>
+
+    <style name="AutofillRemoteViewSyle" parent="@style/AppTheme">
+        <item name="android:background">@color/background_white</item>
+    </style>
 </resources>


### PR DESCRIPTION
Fixes #1072.

This PR is a one liner which sets the background of the call to action at the bottom of the autofill dialogs.

This is both the Unlock Lockwise and Search Lockwise footers.