### PR TITLE
1114-add-missing-locales-screengrab-file

### DIFF
--- a/fastlane/Screengrabfile
+++ b/fastlane/Screengrabfile
@@ -8,7 +8,7 @@ reinstall_app(true)
 app_apk_path ('app/build/outputs/apk/debug/app-debug.apk')
 tests_apk_path ('app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk')
 
-locales ["es-ES", "fr-FR", "it-IT", "de-DE", "en-US", "vi-VN","cs", "ru"]
+locales ["es-ES", "fr-FR", "it-IT", "de-DE", "en-US", "vi-VN", "cs", "ru", "en-GB", "zh-TW", "uk"]
 
 # clear all previously generated screenshots in your local output directory before creating new ones
 clear_previous_screenshots(true)

--- a/fastlane/Screengrabfile
+++ b/fastlane/Screengrabfile
@@ -8,7 +8,7 @@ reinstall_app(true)
 app_apk_path ('app/build/outputs/apk/debug/app-debug.apk')
 tests_apk_path ('app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk')
 
-locales ["es-ES", "fr-FR", "it-IT", "de-DE", "en-US", "vi-VN"]
+locales ["es-ES", "fr-FR", "it-IT", "de-DE", "en-US", "vi-VN","cs", "ru"]
 
 # clear all previously generated screenshots in your local output directory before creating new ones
 clear_previous_screenshots(true)


### PR DESCRIPTION
Fixes #1114

It is not a fix itself for that issue but it adds the missing locales so that when running the screenshots tests all expected locales are used and the app is shown in each one