### PR TITLE
Fixup edit regressions introduced during edit/create refactor.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -39,6 +39,7 @@ class EditItemPresenter(
 
         itemDetailStore.originalItem
             .filterNotNull()
+            .take(1)
             // so we don't overwrite changes when we come back from an
             // interrupt.
             .flatMap { item ->

--- a/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
@@ -133,9 +133,9 @@ open class ItemDetailStore(
         itemToSave.take(1)
             .filterNotNull()
             .map { DataStoreAction.CreateItem(it) }
+            .doAfterNext { stopCreating() }
             .subscribe(dispatcher::dispatch)
             .addTo(sessionDisposable)
-        stopCreating()
     }
 
     private fun stopCreating() {
@@ -190,6 +190,7 @@ open class ItemDetailStore(
             .map { (previous, next) ->
                 DataStoreAction.UpdateItemDetail(previous, next)
             }
+            .doAfterNext { stopEditing() }
             .subscribe(dispatcher::dispatch)
             .addTo(sessionDisposable)
     }

--- a/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
@@ -160,7 +160,8 @@ open class ItemDetailStore(
 
                 val usernames = list
                     .filter(
-                        hostname = item.hostname,
+                        // Default to a blank space, otherwise we get all usernames for any hostname.
+                        hostname = if (item.hostname.isNullOrBlank()) " " else item.hostname,
                         httpRealm = item.httpRealm,
                         formSubmitURL = item.formSubmitURL
                     )

--- a/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
@@ -154,7 +154,7 @@ open class ItemDetailStore(
     }
 
     private fun calculateUnavailableUsernames(getItem: Observable<Optional<ServerPassword>>, excludeItem: Boolean) {
-        Observables.combineLatest(getItem, dataStore.list)
+        Observables.combineLatest(getItem, dataStore.list.take(1))
             .map { (opt, list) ->
                 val item = opt.value ?: return@map emptySet<String>()
 


### PR DESCRIPTION
Fixes #1126
Fixes #1127

This fixes three bugs:

 * in the edit screen, the save button saved, but did not exit the screen. This is the root cause of all these bugs.
 * in the edit screen, the duplicate usernames were updated on save, and thence caused an error to be shown. This is irrelevant if the the save button now closes the edit screen.
 * when no hostname is shown (as in create) the usernames used to detect duplicates was _all_ usernames for _all_ hostnames. This is now prevented. This was unreported.