### PR TITLE
Show errors in create and edit only after the user makes one

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/CreateItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/CreateItemPresenter.kt
@@ -17,7 +17,6 @@ import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.store.ItemDetailStore
-import mozilla.lockbox.support.asOptional
 
 interface CreateItemView : ItemMutationView
 
@@ -68,30 +67,30 @@ class CreateItemPresenter(
         return listOf(RouteAction.ItemList)
     }
 
-    override fun hostnameError(inputText: String, blurredOnce: Boolean) =
+    override fun hostnameError(inputText: String, showingErrors: Boolean): Int? =
         when {
             TextUtils.isEmpty(inputText) ->
-                R.string.hostname_empty_invalid_text after blurredOnce
+                R.string.hostname_empty_invalid_text `when` showingErrors
 
             inputText.length <= 7 && "http://".startsWith(inputText) ->
-                R.string.hostname_invalid_text after blurredOnce
+                R.string.hostname_invalid_text `when` showingErrors
 
             inputText.length <= 8 && "https://".startsWith(inputText) ->
-                R.string.hostname_invalid_text after blurredOnce
+                R.string.hostname_invalid_text `when` showingErrors
 
             !URLUtil.isHttpUrl(inputText) && !URLUtil.isHttpsUrl(inputText) ->
                 R.string.hostname_invalid_text
 
             !minimalHostRegex.matches(inputText) ->
-                R.string.hostname_invalid_host after blurredOnce
+                R.string.hostname_invalid_host `when` showingErrors
 
             else -> null
-        }.asOptional()
+        }
 
-    private infix fun Int.after(blurredOnce: Boolean) =
-        if (blurredOnce) {
+    private infix fun Int.`when`(showingErrors: Boolean) =
+        if (showingErrors) {
             this
         } else {
-            R.string.undisplayed_credential_mutation_error
+            R.string.hidden_credential_mutation_error
         }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -80,5 +80,5 @@ class EditItemPresenter(
         } ?: listOf(RouteAction.ItemList)
     }
 
-    override fun hostnameError(inputText: String): Optional<Int> = null.asOptional()
+    override fun hostnameError(inputText: String, blurredOnce: Boolean): Optional<Int> = null.asOptional()
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -18,8 +18,6 @@ import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.model.ItemDetailViewModel
 import mozilla.lockbox.store.ItemDetailStore
-import mozilla.lockbox.support.Optional
-import mozilla.lockbox.support.asOptional
 
 interface EditItemView : ItemMutationView {
     fun updateItem(item: ItemDetailViewModel)
@@ -80,5 +78,5 @@ class EditItemPresenter(
         } ?: listOf(RouteAction.ItemList)
     }
 
-    override fun hostnameError(inputText: String, blurredOnce: Boolean): Optional<Int> = null.asOptional()
+    override fun hostnameError(inputText: String, showingErrors: Boolean): Int? = null
 }

--- a/app/src/main/java/mozilla/lockbox/view/ItemMutationFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemMutationFragment.kt
@@ -9,13 +9,14 @@ package mozilla.lockbox.view
 import android.os.Bundle
 import android.text.method.PasswordTransformationMethod
 import android.view.View
+import android.widget.EditText
 import androidx.annotation.StringRes
 import androidx.appcompat.widget.Toolbar
 import com.google.android.material.textfield.TextInputLayout
 import com.jakewharton.rxbinding2.support.v7.widget.navigationClicks
 import com.jakewharton.rxbinding2.view.clicks
+import com.jakewharton.rxbinding2.view.focusChanges
 import com.jakewharton.rxbinding2.widget.textChanges
-import com.jakewharton.rxrelay2.BehaviorRelay
 import io.reactivex.Observable
 import kotlinx.android.synthetic.main.fragment_create_item.view.*
 import kotlinx.android.synthetic.main.fragment_edit_item.*
@@ -34,11 +35,8 @@ import mozilla.lockbox.presenter.ItemMutationView
 import mozilla.lockbox.support.assertOnUiThread
 
 open class ItemMutationFragment : BackableFragment(), ItemMutationView {
-
-    private val togglePasswordVisibility: BehaviorRelay<Unit> = BehaviorRelay.create()
-
     override val togglePasswordClicks: Observable<Unit>
-        get() = view!!.btnPasswordToggle.clicks().mergeWith(togglePasswordVisibility)
+        get() = view!!.btnPasswordToggle.clicks().mergeWith(passwordFocus.map { Unit })
 
     override val closeEntryClicks: Observable<Unit>
         get() = view!!.toolbar.navigationClicks()
@@ -54,6 +52,15 @@ open class ItemMutationFragment : BackableFragment(), ItemMutationView {
 
     override val passwordChanged: Observable<String>
         get() = view!!.inputPassword.textChanges().map { it.toString() }
+
+    override val hostnameFocus
+        get() = focusChanges(view!!.inputHostname)
+
+    override val passwordFocus
+        get() = focusChanges(view!!.inputPassword)
+
+    override val usernameFocus
+        get() = focusChanges(view!!.inputUsername)
 
     override var isPasswordVisible: Boolean = false
         set(value) {
@@ -97,23 +104,17 @@ open class ItemMutationFragment : BackableFragment(), ItemMutationView {
         }
     }
 
-    open fun setupKeyboardFocus(view: View) {
-        view.inputUsername.onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
+    private fun focusChanges(view: EditText): Observable<Boolean> =
+        view.focusChanges().doOnNext { hasFocus ->
             if (!hasFocus) {
                 closeKeyboard()
             } else {
-                view.inputUsername?.setSelection(view.inputUsername?.length() ?: 0)
+                view.setSelection(view.length())
             }
         }
 
-        view.inputPassword.onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
-            togglePasswordVisibility.accept(Unit)
-            if (!hasFocus) {
-                closeKeyboard()
-            } else {
-                view.inputPassword?.setSelection(view.inputPassword?.length() ?: 0)
-            }
-        }
+    open fun setupKeyboardFocus(view: View) {
+        // NOP
     }
 
     override fun setSaveEnabled(enabled: Boolean) {

--- a/app/src/main/java/mozilla/lockbox/view/ItemMutationFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemMutationFragment.kt
@@ -114,7 +114,7 @@ open class ItemMutationFragment : BackableFragment(), ItemMutationView {
         }
 
     open fun setupKeyboardFocus(view: View) {
-        // NOP
+        // Empty here, but will have implementations specific to create and edit.
     }
 
     override fun setSaveEnabled(enabled: Boolean) {

--- a/app/src/main/res/values/non_localizable_strings.xml
+++ b/app/src/main/res/values/non_localizable_strings.xml
@@ -18,7 +18,8 @@
     <string name="telemetry_server_endpoint" translatable="false">https://incoming.telemetry.mozilla.org</string>
     <!-- This is the label for a button only available on test builds to skip the authentication step and immediately use test data -->
     <string name="placeholder_skip_fxa">Use test data</string>
-
+    <!-- The text is never displayed, but the error is a placeholder to stop the save button being enabled. -->
+    <string name="hidden_credential_mutation_error" translatable="false">Hidden</string>
     <!-- CURRENTLY UNUSED BUT RESERVED FOR FUTURE USE -->
     <!-- This is the text displayed on the button of the network availability error message -->
     <!--<string name="retry">Retry</string>-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -279,8 +279,6 @@
     <!-- This is the title of the edit login page. -->
     <string name="edit_login_title">Edit Login</string>
 
-    <string name="undisplayed_credential_mutation_error" translatable="false">Undisplayed</string>
-
     <!-- This is the error message that is shown in edit or create view when input text for password is not valid. -->
     <string name="password_invalid_text">Password cannot be empty</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -279,6 +279,8 @@
     <!-- This is the title of the edit login page. -->
     <string name="edit_login_title">Edit Login</string>
 
+    <string name="undisplayed_credential_mutation_error" translatable="false">Undisplayed</string>
+
     <!-- This is the error message that is shown in edit or create view when input text for password is not valid. -->
     <string name="password_invalid_text">Password cannot be empty</string>
 
@@ -299,6 +301,9 @@
 
     <!-- This is an error message shown below the hostname field of the create new login page when a hostname is invalid. -->
     <string name="hostname_invalid_text">Web address must contain \“https://\“ or \“http://\“</string>
+
+    <!-- This is an error message shown below the hostname field of the create new login page when a hostname is invalid. -->
+    <string name="hostname_invalid_host">Web address must have a valid hostname</string>
 
     <!-- This is the error message that is shown in the create view when input text for hostname is empty. -->
     <string name="hostname_empty_invalid_text">Hostname cannot be empty</string>

--- a/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
@@ -212,31 +212,31 @@ class CreateItemPresenterTest {
     @Test
     fun `testing various hostname errors`() {
         // empty string
-        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("", false).value)
-        assertEquals(R.string.hostname_empty_invalid_text, subject.hostnameError("", true).value)
+        assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("", false))
+        assertEquals(R.string.hostname_empty_invalid_text, subject.hostnameError("", true))
 
         // not starting with http or https
-        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("h", false).value)
-        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("ht", false).value)
-        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("htt", false).value)
-        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("http", false).value)
-        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("https", false).value)
-        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("https:", false).value)
-        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("https://", false).value)
-        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("http://", false).value)
+        assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("h", false))
+        assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("ht", false))
+        assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("htt", false))
+        assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("http", false))
+        assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("https", false))
+        assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("https:", false))
+        assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("https://", false))
+        assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("http://", false))
 
-        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("f", false).value)
-        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("f", true).value)
-        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("htt", true).value)
+        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("f", false))
+        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("f", true))
+        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("htt", true))
 
         // not being a valid URL
-        assertEquals(R.string.hostname_invalid_host, subject.hostnameError("https://a", true).value)
+        assertEquals(R.string.hostname_invalid_host, subject.hostnameError("https://a", true))
 
         // but being a valid URL is ok.
-        assertNull(subject.hostnameError("https://mozilla.com", false).value)
-        assertNull(subject.hostnameError("https://mozilla.com", true).value)
+        assertNull(subject.hostnameError("https://mozilla.com", false))
+        assertNull(subject.hostnameError("https://mozilla.com", true))
 
-        assertNull(subject.hostnameError("https://127.0.0.1", true).value)
-        assertNull(subject.hostnameError("https://127.0.0.1:44", true).value)
+        assertNull(subject.hostnameError("https://127.0.0.1", true))
+        assertNull(subject.hostnameError("https://127.0.0.1:44", true))
     }
 }

--- a/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
@@ -12,6 +12,7 @@ import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.lockbox.R
 import mozilla.lockbox.action.DialogAction
 import mozilla.lockbox.action.ItemDetailAction
 import mozilla.lockbox.action.RouteAction
@@ -21,11 +22,12 @@ import mozilla.lockbox.log
 import mozilla.lockbox.model.ItemDetailViewModel
 import mozilla.lockbox.store.ItemDetailStore
 import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
-import org.mockito.Mockito.spy
 import org.powermock.api.mockito.PowerMockito
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -52,6 +54,17 @@ class CreateItemPresenterTest {
         val passwordChangedStub = BehaviorSubject.createDefault("")
         override val passwordChanged: Observable<String>
             get() = passwordChangedStub
+
+        private val hostnameFocusStub = BehaviorSubject.createDefault(false)
+        private val usernameFocusStub = BehaviorSubject.createDefault(false)
+        private val passwordFocusStub = BehaviorSubject.createDefault(false)
+
+        override val hostnameFocus: Observable<Boolean>
+            get() = hostnameFocusStub
+        override val usernameFocus: Observable<Boolean>
+            get() = usernameFocusStub
+        override val passwordFocus: Observable<Boolean>
+            get() = passwordFocusStub
 
         override fun closeKeyboard() {
             log.info("close keyboard")
@@ -89,7 +102,7 @@ class CreateItemPresenterTest {
 
     val dispatcher = Dispatcher()
     val dispatcherObserver = TestObserver.create<Action>()!!
-    val view: FakeCreateView = spy(FakeCreateView())
+    val view: FakeCreateView = FakeCreateView()
 
     private val isPasswordVisibleStub = BehaviorSubject.createDefault(false)
     private val unavailableUsernamesStub = BehaviorSubject.createDefault(emptySet<String>())
@@ -194,5 +207,36 @@ class CreateItemPresenterTest {
 
         view.usernameChangedStub.onNext("jane.appleseed")
         Assert.assertNull(view.usernameError)
+    }
+
+    @Test
+    fun `testing various hostname errors`() {
+        // empty string
+        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("", false).value)
+        assertEquals(R.string.hostname_empty_invalid_text, subject.hostnameError("", true).value)
+
+        // not starting with http or https
+        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("h", false).value)
+        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("ht", false).value)
+        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("htt", false).value)
+        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("http", false).value)
+        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("https", false).value)
+        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("https:", false).value)
+        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("https://", false).value)
+        assertEquals(R.string.undisplayed_credential_mutation_error, subject.hostnameError("http://", false).value)
+
+        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("f", false).value)
+        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("f", true).value)
+        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("htt", true).value)
+
+        // not being a valid URL
+        assertEquals(R.string.hostname_invalid_host, subject.hostnameError("https://a", true).value)
+
+        // but being a valid URL is ok.
+        assertNull(subject.hostnameError("https://mozilla.com", false).value)
+        assertNull(subject.hostnameError("https://mozilla.com", true).value)
+
+        assertNull(subject.hostnameError("https://127.0.0.1", true).value)
+        assertNull(subject.hostnameError("https://127.0.0.1:44", true).value)
     }
 }

--- a/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/EditItemPresenterTest.kt
@@ -59,6 +59,17 @@ class EditItemPresenterTest {
         override val passwordChanged: Observable<String>
             get() = passwordChangedStub
 
+        private val hostnameFocusStub = BehaviorSubject.createDefault(false)
+        private val usernameFocusStub = BehaviorSubject.createDefault(false)
+        private val passwordFocusStub = BehaviorSubject.createDefault(false)
+
+        override val hostnameFocus: Observable<Boolean>
+            get() = hostnameFocusStub
+        override val usernameFocus: Observable<Boolean>
+            get() = usernameFocusStub
+        override val passwordFocus: Observable<Boolean>
+            get() = passwordFocusStub
+
         override fun closeKeyboard() {
             log.info("close keyboard")
         }


### PR DESCRIPTION
Fixes #1120

This includes a number of fixes in displaying errors during manual create, which is inherited by edit. 

 * only show errors after the user has typed them
  - don't show an error until the input text has been blurred at least once.
  - don't start with an empty hostname / password with an error
  - if the user is typing `http` or `https` then don't show an error until they make a mistake
 * disable the save button even when the user has detected them 
 * ensure that the hostname is minimally at least two words, separated by dots.