### PR TITLE
Update string names to send update upstream to l10n

### DIFF
--- a/app/src/main/res/layout/fragment_onboarding_confirmation.xml
+++ b/app/src/main/res/layout/fragment_onboarding_confirmation.xml
@@ -38,7 +38,7 @@
             android:drawablePadding="@dimen/onboarding_drawable_padding"
             android:layout_gravity="center_horizontal"
             android:drawableStart="@drawable/ic_access"
-            android:text="@string/access_description"
+            android:text="@string/onboarding_access_description"
     />
 
     <TextView
@@ -55,7 +55,7 @@
             android:maxWidth="@dimen/onboarding_max_width"
             android:drawablePadding="@dimen/onboarding_drawable_padding"
             android:drawableStart="@drawable/ic_security"
-            android:text="@string/security_description"
+            android:text="@string/onboarding_security_description"
     />
     <TextView
             android:layout_width="wrap_content"
@@ -70,7 +70,7 @@
             android:maxWidth="@dimen/onboarding_max_width"
             android:drawablePadding="@dimen/onboarding_drawable_padding"
             android:drawableStart="@drawable/ic_convenience"
-            android:text="@string/convenience_description"
+            android:text="@string/onboarding_convenience_description"
     />
 
     <View

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -219,11 +219,11 @@ Pro jejich zobrazení a synchronizaci se přihlaste ke svému účtu Firefoxu.</
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">Dokončit</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">Přistupujte ke svým přihlašovacím údajům uloženým ve Firefoxu i ze svého telefonu</string>
+    <string name="onboarding_access_description">Přistupujte ke svým přihlašovacím údajům uloženým ve Firefoxu i ze svého telefonu</string>
     <!-- This description of the app security is shown on the final onboarding screen. %s will be replaced with the security link. -->
-    <string name="security_description">Synchronizace mezi zařízeními zabezpečená pomocí 256-bitového šifrování</string>
+    <string name="onboarding_security_description">Synchronizace mezi zařízeními zabezpečená pomocí 256-bitového šifrování</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">Aplikaci snadno odemknete pomocí otisku prstu</string>
+    <string name="onboarding_convenience_description">Aplikaci snadno odemknete pomocí otisku prstu</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">Zabezpečte své zařízení.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -221,11 +221,11 @@
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">Abschließen</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">Greife über dein Handy auf alle in Firefox gespeicherten Zugangsdaten zu</string>
+    <string name="onboarding_access_description">Greife über dein Handy auf alle in Firefox gespeicherten Zugangsdaten zu</string>
     <!-- This description of the app security is shown on the final onboarding screen. -->
-    <string name="security_description">Synchronisiere zwischen Geräten mit sicherer 256-Bit-Verschlüsselung</string>
+    <string name="onboarding_security_description">Synchronisiere zwischen Geräten mit sicherer 256-Bit-Verschlüsselung</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">Entsperre die App einfach per Fingerabdruck</string>
+    <string name="onboarding_convenience_description">Entsperre die App einfach per Fingerabdruck</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">Sichere dein Gerät.</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -220,11 +220,11 @@
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">Finish</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">Access logins saved to Firefox from your phone</string>
+    <string name="onboarding_access_description">Access logins saved to Firefox from your phone</string>
     <!-- This description of the app security is shown on the final onboarding screen. %s will be replaced with the security link. -->
-    <string name="security_description">Synchronise between devices with secure 256-bit encryption</string>
+    <string name="onboarding_security_description">Synchronise between devices with secure 256-bit encryption</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">Unlock the app with ease using your fingerprint</string>
+    <string name="onboarding_convenience_description">Unlock the app with ease using your fingerprint</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">Secure your device.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -221,11 +221,11 @@
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">Terminar</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">Acceder a los usuarios guardados en Firefox desde el teléfono</string>
+    <string name="onboarding_access_description">Acceder a los usuarios guardados en Firefox desde el teléfono</string>
     <!-- This description of the app security is shown on the final onboarding screen. -->
-    <string name="security_description">Sincroniza dispositivos con la seguridad que te ofrece Cifrado de 256 bit</string>
+    <string name="onboarding_security_description">Sincroniza dispositivos con la seguridad que te ofrece Cifrado de 256 bit</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">Desbloquea rápidamente la aplicación mediante tu huella digital</string>
+    <string name="onboarding_convenience_description">Desbloquea rápidamente la aplicación mediante tu huella digital</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">Protege tu dispositivo.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -218,11 +218,11 @@
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">Terminer</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">Accédez depuis votre téléphone aux identifiants enregistrés dans Firefox</string>
+    <string name="onboarding_access_description">Accédez depuis votre téléphone aux identifiants enregistrés dans Firefox</string>
     <!-- This description of the app security is shown on the final onboarding screen. -->
-    <string name="security_description">Synchronisez vos appareils avec un chiffrement 256 bits</string>
+    <string name="onboarding_security_description">Synchronisez vos appareils avec un chiffrement 256 bits</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">Déverrouillez facilement l’application avec votre empreinte digitale</string>
+    <string name="onboarding_convenience_description">Déverrouillez facilement l’application avec votre empreinte digitale</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">Sécurisez votre appareil.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -225,12 +225,12 @@
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">Fine</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">Accedi alle credenziali salvate in Firefox dal tuo telefono</string>
+    <string name="onboarding_access_description">Accedi alle credenziali salvate in Firefox dal tuo telefono</string>
     <!-- This description of the app security is shown on the final onboarding screen. -->
-    <string name="security_description">Sincronizza in modo sicuro più dispositivi con crittografia a 256 bit</string>
+    <string name="onboarding_security_description">Sincronizza in modo sicuro più dispositivi con crittografia a 256 bit</string>
 
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">Sblocca comodamente l’app utilizzando la tua impronta digitale</string>
+    <string name="onboarding_convenience_description">Sblocca comodamente l’app utilizzando la tua impronta digitale</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">Proteggi il tuo dispositivo.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -220,11 +220,11 @@
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">Завершить</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">Получите доступ к логинам, сохранённым в Firefox, с вашего телефона</string>
+    <string name="onboarding_access_description">Получите доступ к логинам, сохранённым в Firefox, с вашего телефона</string>
     <!-- This description of the app security is shown on the final onboarding screen. %s will be replaced with the security link. -->
-    <string name="security_description">Синхронизация между устройствами с безопасным 256-битным шифрованием</string>
+    <string name="onboarding_security_description">Синхронизация между устройствами с безопасным 256-битным шифрованием</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">Разблокируйте приложение с легкостью, используя отпечаток пальца</string>
+    <string name="onboarding_convenience_description">Разблокируйте приложение с легкостью, используя отпечаток пальца</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">Защитите своё устройство.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -223,11 +223,11 @@
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">Завершити</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">Доступ до збережених у Firefox паролів з телефону</string>
+    <string name="onboarding_access_description">Доступ до збережених у Firefox паролів з телефону</string>
     <!-- This description of the app security is shown on the final onboarding screen. %s will be replaced with the security link. -->
-    <string name="security_description">Синхронізуйте між пристроями із захищеним 256-бітним шифруванням</string>
+    <string name="onboarding_security_description">Синхронізуйте між пристроями із захищеним 256-бітним шифруванням</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">Просте розблокування за допомогою відбитку пальця</string>
+    <string name="onboarding_convenience_description">Просте розблокування за допомогою відбитку пальця</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">Захистіть свій пристрій.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -220,11 +220,11 @@
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">Kết thúc</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">Truy cập thông tin đăng nhập được lưu vào Firefox từ điện thoại của bạn</string>
+    <string name="onboarding_access_description">Truy cập thông tin đăng nhập được lưu vào Firefox từ điện thoại của bạn</string>
     <!-- This description of the app security is shown on the final onboarding screen. -->
-    <string name="security_description">Đồng bộ hóa giữa các thiết bị với Mã hóa 256-bit</string>
+    <string name="onboarding_security_description">Đồng bộ hóa giữa các thiết bị với Mã hóa 256-bit</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">Mở khóa ứng dụng một cách dễ dàng bằng dấu vân tay của bạn</string>
+    <string name="onboarding_convenience_description">Mở khóa ứng dụng một cách dễ dàng bằng dấu vân tay của bạn</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">Bảo mật thiết bị của bạn.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -219,11 +219,11 @@
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">完成</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">在您的手機使用儲存到 Firefox 的登入資訊</string>
+    <string name="onboarding_access_description">在您的手機使用儲存到 Firefox 的登入資訊</string>
     <!-- This description of the app security is shown on the final onboarding screen. %s will be replaced with the security link. -->
-    <string name="security_description">使用 256 位元加密，安全於裝置間同步</string>
+    <string name="onboarding_security_description">使用 256 位元加密，安全於裝置間同步</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">輕鬆使用指紋解鎖應用程式</string>
+    <string name="onboarding_convenience_description">輕鬆使用指紋解鎖應用程式</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">保護您的裝置。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,11 +225,11 @@
     <!-- This is the button to dismiss the final onboarding screen -->
     <string name="finish">Finish</string>
     <!-- This description of the app functionality is shown on the final onboarding screen -->
-    <string name="access_description">Access logins saved to Firefox from your phone</string>
+    <string name="onboarding_access_description">Access logins saved to Firefox from your phone</string>
     <!-- This description of the app security is shown on the final onboarding screen. %s will be replaced with the security link. -->
-    <string name="security_description">Sync between devices with secure 256-bit encryption</string>
+    <string name="onboarding_security_description">Sync between devices with secure 256-bit encryption</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
-    <string name="convenience_description">Unlock the app with ease using your fingerprint</string>
+    <string name="onboarding_convenience_description">Unlock the app with ease using your fingerprint</string>
 
     <!-- This is the title of the device security dialog box. -->
     <string name="secure_your_device">Secure your device.</string>


### PR DESCRIPTION
Fixes #1138 

* Changes the name of the onboarding strings to force an update upstream in l10n (the security onboarding string was previously two different strings, but has been simplified to one - see #1138)