### PR TITLE
1161: route to display item on create

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/CreateItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/CreateItemPresenter.kt
@@ -10,7 +10,6 @@ import android.text.TextUtils
 import android.webkit.URLUtil
 import io.reactivex.rxkotlin.addTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import mozilla.appservices.logins.ServerPassword
 import mozilla.lockbox.R
 import mozilla.lockbox.action.DialogAction
 import mozilla.lockbox.action.ItemDetailAction

--- a/app/src/main/java/mozilla/lockbox/presenter/CreateItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/CreateItemPresenter.kt
@@ -60,7 +60,7 @@ class CreateItemPresenter(
         }
     }
 
-    override fun dismissChangesAction(hasChanges: Boolean): List<Action> =
+    override fun dismissChangesActions(hasChanges: Boolean): List<Action> =
         if (hasChanges) {
             listOf(DialogAction.DiscardChangesCreateDialog)
         } else {
@@ -68,11 +68,15 @@ class CreateItemPresenter(
         }
 
     override fun endEditingActions(): List<Action> {
-        val list = itemDetailStore.findSavedItem().blockingIterable().iterator().next()
-        return listOf(
-            RouteAction.ItemList,
-            RouteAction.DisplayItem(list.first().id)
-        )
+        val latestSavedItem = itemDetailStore.findLatestSavedItem().blockingIterable().iterator().next()
+        return if (latestSavedItem.value != null) {
+            listOf(
+                RouteAction.ItemList,
+                RouteAction.DisplayItem(latestSavedItem.value.id)
+            )
+        } else {
+            listOf(RouteAction.ItemList)
+        }
     }
 
     override fun hostnameError(inputText: String, showingErrors: Boolean): Int? =

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -6,6 +6,7 @@
 
 package mozilla.lockbox.presenter
 
+import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
 import io.reactivex.rxkotlin.addTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -72,10 +73,17 @@ class EditItemPresenter(
             }
         } ?: listOf(ItemDetailAction.EndEditItemSession)
 
-    override fun endEditingActions() =
+    override fun endEditingActions(): Observable<List<Action>> =
         itemId?.let {
-            listOf(RouteAction.ItemList, RouteAction.DisplayItem(it))
-        } ?: listOf(RouteAction.ItemList)
+            Observable.just(
+                listOf<Action>(
+                    RouteAction.ItemList,
+                    RouteAction.DisplayItem(it)
+                )
+            )
+        } ?: Observable.just(
+            listOf<Action>(RouteAction.ItemList)
+        )
 
     override fun hostnameError(inputText: String, showingErrors: Boolean): Int? = null
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -66,11 +66,11 @@ class EditItemPresenter(
     override fun dismissChangesAction(hasChanges: Boolean) =
         itemId?.let {
             if (hasChanges) {
-                DialogAction.DiscardChangesDialog(it)
+                listOf(DialogAction.DiscardChangesDialog(it))
             } else {
                 null
             }
-        } ?: ItemDetailAction.EndEditItemSession
+        } ?: listOf(ItemDetailAction.EndEditItemSession)
 
     override fun endEditingActions() =
         itemId?.let {

--- a/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/EditItemPresenter.kt
@@ -63,7 +63,7 @@ class EditItemPresenter(
             }
         } ?: listOf(ItemDetailAction.EndEditItemSession)
 
-    override fun dismissChangesAction(hasChanges: Boolean) =
+    override fun dismissChangesActions(hasChanges: Boolean) =
         itemId?.let {
             if (hasChanges) {
                 listOf(DialogAction.DiscardChangesDialog(it))

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemMutationPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemMutationPresenter.kt
@@ -62,7 +62,7 @@ abstract class ItemMutationPresenter(
 
         view.closeEntryClicks
             .flatMap { itemDetailStore.isDirty.take(1) }
-            .flatMapIterable { dismissChangesAction(it) }
+            .flatMapIterable { dismissChangesActions(it) }
             .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
 
@@ -190,13 +190,13 @@ abstract class ItemMutationPresenter(
     override fun onBackPressed(): Boolean {
         itemDetailStore.isDirty
             .take(1)
-            .flatMapIterable { dismissChangesAction(it) }
+            .flatMapIterable { dismissChangesActions(it) }
             .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
         return true
     }
 
-    abstract fun dismissChangesAction(hasChanges: Boolean): List<Action>
+    abstract fun dismissChangesActions(hasChanges: Boolean): List<Action>
     abstract fun saveChangesActions(hasChanges: Boolean): List<Action>
     abstract fun endEditingActions(): List<Action>
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemMutationPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemMutationPresenter.kt
@@ -136,10 +136,9 @@ abstract class ItemMutationPresenter(
         itemDetailStore.isEditing
             .distinctUntilChanged()
             .filter { !it }
-            .flatMapIterable {
-                view.closeKeyboard()
-                endEditingActions()
-            }
+            .doOnNext{ view.closeKeyboard() }
+            .flatMap { endEditingActions() }
+            .flatMapIterable { it }
             .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
     }
@@ -198,5 +197,5 @@ abstract class ItemMutationPresenter(
 
     abstract fun dismissChangesActions(hasChanges: Boolean): List<Action>
     abstract fun saveChangesActions(hasChanges: Boolean): List<Action>
-    abstract fun endEditingActions(): List<Action>
+    abstract fun endEditingActions(): Observable<List<Action>>
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemMutationPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemMutationPresenter.kt
@@ -62,7 +62,7 @@ abstract class ItemMutationPresenter(
 
         view.closeEntryClicks
             .flatMap { itemDetailStore.isDirty.take(1) }
-            .map { dismissChangesAction(it) }
+            .flatMapIterable { dismissChangesAction(it) }
             .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
 
@@ -190,15 +190,13 @@ abstract class ItemMutationPresenter(
     override fun onBackPressed(): Boolean {
         itemDetailStore.isDirty
             .take(1)
-            .map {
-                dismissChangesAction(it)
-            }
+            .flatMapIterable { dismissChangesAction(it) }
             .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
         return true
     }
 
-    abstract fun dismissChangesAction(hasChanges: Boolean): Action
+    abstract fun dismissChangesAction(hasChanges: Boolean): List<Action>
     abstract fun saveChangesActions(hasChanges: Boolean): List<Action>
     abstract fun endEditingActions(): List<Action>
 }

--- a/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
@@ -209,12 +209,12 @@ open class ItemDetailStore(
         sessionDisposable.clear()
     }
 
-    fun findSavedItem(): Observable<List<ServerPassword>> {
+    fun findLatestSavedItem(): Observable<Optional<ServerPassword>> {
         val item = _itemToSave.value?.value
         return dataStore.filteredList(
             item?.username,
             item?.password,
             item?.hostname
-        )
+        ).map { it.firstOrNull().asOptional() }
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
@@ -132,8 +132,12 @@ open class ItemDetailStore(
     private fun saveCreateChanges() {
         itemToSave.take(1)
             .filterNotNull()
-            .map { DataStoreAction.CreateItem(it) }
-            .doAfterNext { stopCreating() }
+            .map {
+                DataStoreAction.CreateItem(it)
+            }
+            .doAfterNext {
+                stopCreating()
+            }
             .subscribe(dispatcher::dispatch)
             .addTo(sessionDisposable)
     }
@@ -153,7 +157,10 @@ open class ItemDetailStore(
         calculateUnavailableUsernames(originalItem, true)
     }
 
-    private fun calculateUnavailableUsernames(getItem: Observable<Optional<ServerPassword>>, excludeItem: Boolean) {
+    private fun calculateUnavailableUsernames(
+        getItem: Observable<Optional<ServerPassword>>,
+        excludeItem: Boolean
+    ) {
         Observables.combineLatest(getItem, dataStore.list.take(1))
             .map { (opt, list) ->
                 val item = opt.value ?: return@map emptySet<String>()
@@ -185,9 +192,9 @@ open class ItemDetailStore(
 
     private fun saveEditChanges() {
         Observables.combineLatest(
-                originalItem.take(1).filterNotNull(),
-                itemToSave.take(1).filterNotNull()
-            )
+            originalItem.take(1).filterNotNull(),
+            itemToSave.take(1).filterNotNull()
+        )
             .map { (previous, next) ->
                 DataStoreAction.UpdateItemDetail(previous, next)
             }
@@ -200,5 +207,14 @@ open class ItemDetailStore(
         _isEditing.onNext(false)
         _originalItem.onNext(null.asOptional())
         sessionDisposable.clear()
+    }
+
+    fun findSavedItem(): Observable<List<ServerPassword>> {
+        val item = _itemToSave.value?.value
+        return dataStore.filteredList(
+            item?.username,
+            item?.password,
+            item?.hostname
+        )
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ItemDetailStore.kt
@@ -51,6 +51,8 @@ open class ItemDetailStore(
     private val _itemToSave = ReplaySubject.createWithSize<Optional<ServerPassword>>(1)
     val itemToSave: Observable<Optional<ServerPassword>> = _itemToSave
 
+    val recentActions: Observable<Optional<DataStore.ActionRecord>> = dataStore.actionRecord
+
     private val _unavailableUsernames = BehaviorSubject.createDefault(emptySet<String>())
     val unavailableUsernames: Observable<Set<String>> = _unavailableUsernames
 

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -57,6 +57,7 @@ open class RouteStore(
                         is RouteAction.AutoLockSetting,
                         is RouteAction.DialogFragment,
                         is RouteAction.SystemIntent,
+                        is RouteAction.CreateItem,
                         is ToastNotificationAction -> true
                         else -> false
                     }

--- a/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
@@ -126,7 +126,7 @@ class CreateItemPresenterTest {
         `when`(store.unavailableUsernames).thenReturn(unavailableUsernamesStub)
         `when`(store.isDirty).thenReturn(isDirtyStub)
         `when`(store.isEditing).thenReturn(isEditingStub)
-        `when`(store.findSavedItem()).thenReturn(findSavedItemStub)
+        `when`(store.findLatestSavedItem()).thenReturn(findSavedItemStub)
         store
     }
 

--- a/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
@@ -23,6 +23,7 @@ import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.log
 import mozilla.lockbox.model.ItemDetailViewModel
 import mozilla.lockbox.store.ItemDetailStore
+import mozilla.lockbox.support.asOptional
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -118,7 +119,7 @@ class CreateItemPresenterTest {
     private val unavailableUsernamesStub = BehaviorSubject.createDefault(emptySet<String>())
     private val isDirtyStub = BehaviorSubject.createDefault(false)
     private val isEditingStub = BehaviorSubject.createDefault(true)
-    private val findSavedItemStub = Observable.just(listOf(fakeItem))
+    private val findSavedItemStub = Observable.just(fakeItem.asOptional())
 
     val itemDetailStore: ItemDetailStore by lazy {
         val store = PowerMockito.mock(ItemDetailStore::class.java)!!

--- a/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
@@ -23,7 +23,6 @@ import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.log
 import mozilla.lockbox.model.ItemDetailViewModel
 import mozilla.lockbox.store.ItemDetailStore
-import okhttp3.Route
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull


### PR DESCRIPTION
Fixes #1161 

## Testing and Review Notes
* save routes to the item detail view for the new entry
* back button works for the new entry, routing back to the item list instead of back to the create screen

## Screenshots or Videos
<img width="325" alt="save_route_to_display" src="https://user-images.githubusercontent.com/43795363/73654494-29456180-468c-11ea-9fd7-6477ad7c5cf3.gif">


## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
