### PR TITLE
Update ---bug-report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F41E Bug report"
 about: Create a report to help us improve
-labels: "type: defect"
+labels: "defect"
 
 ---
 


### PR DESCRIPTION
As the label name changed, now it's not auto-added when adding a new issue.
This change will auto-assign the `defect` label for new issues.