### PR TITLE
1164: Improve error messaging for create

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/CreateItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/CreateItemPresenter.kt
@@ -78,6 +78,10 @@ class CreateItemPresenter(
             TextUtils.isEmpty(inputText) ->
                 R.string.hostname_empty_invalid_text `when` showingErrors
 
+            !minimalHostRegex.matches(inputText) &&
+                "http://".startsWith(inputText) || "https://".startsWith(inputText) ->
+                R.string.hostname_invalid_host `when` showingErrors
+
             inputText.length <= 7 && "http://".startsWith(inputText) ->
                 R.string.hostname_invalid_text `when` showingErrors
 
@@ -87,8 +91,6 @@ class CreateItemPresenter(
             !URLUtil.isHttpUrl(inputText) && !URLUtil.isHttpsUrl(inputText) ->
                 R.string.hostname_invalid_text
 
-            !minimalHostRegex.matches(inputText) ->
-                R.string.hostname_invalid_host `when` showingErrors
 
             else -> null
         }

--- a/app/src/main/java/mozilla/lockbox/presenter/CreateItemPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/CreateItemPresenter.kt
@@ -78,19 +78,17 @@ class CreateItemPresenter(
             TextUtils.isEmpty(inputText) ->
                 R.string.hostname_empty_invalid_text `when` showingErrors
 
-            !minimalHostRegex.matches(inputText) &&
-                "http://".startsWith(inputText) || "https://".startsWith(inputText) ->
-                R.string.hostname_invalid_host `when` showingErrors
-
-            inputText.length <= 7 && "http://".startsWith(inputText) ->
+            inputText.length < 7 && "http://".startsWith(inputText) ->
                 R.string.hostname_invalid_text `when` showingErrors
 
-            inputText.length <= 8 && "https://".startsWith(inputText) ->
+            inputText.length < 8 && "https://".startsWith(inputText) ->
                 R.string.hostname_invalid_text `when` showingErrors
 
             !URLUtil.isHttpUrl(inputText) && !URLUtil.isHttpsUrl(inputText) ->
                 R.string.hostname_invalid_text
 
+            !minimalHostRegex.matches(inputText) ->
+                R.string.hostname_invalid_host `when` showingErrors
 
             else -> null
         }

--- a/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/CreateItemPresenterTest.kt
@@ -208,7 +208,7 @@ class CreateItemPresenterTest {
         Assert.assertNotNull(view.usernameError)
 
         view.usernameChangedStub.onNext("jane.appleseed")
-        Assert.assertNull(view.usernameError)
+        assertNull(view.usernameError)
     }
 
     @Test
@@ -227,12 +227,15 @@ class CreateItemPresenterTest {
         assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("https://", false))
         assertEquals(R.string.hidden_credential_mutation_error, subject.hostnameError("http://", false))
 
-        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("f", false))
+        // must start with http:// or https://
         assertEquals(R.string.hostname_invalid_text, subject.hostnameError("f", true))
+        assertEquals(R.string.hostname_invalid_text, subject.hostnameError("fhtt", true))
         assertEquals(R.string.hostname_invalid_text, subject.hostnameError("htt", true))
 
-        // not being a valid URL
+        // not a valid URL
         assertEquals(R.string.hostname_invalid_host, subject.hostnameError("https://a", true))
+        assertEquals(R.string.hostname_invalid_host, subject.hostnameError("http://", true))
+        assertEquals(R.string.hostname_invalid_host, subject.hostnameError("https://", true))
 
         // but being a valid URL is ok.
         assertNull(subject.hostnameError("https://mozilla.com", false))


### PR DESCRIPTION
Fixes #1164 

## Testing and Review Notes
**Previous functionality:** type in "http://" and click into username field. See that the `Web address must contain \“https://\“ or \“http://\“` error message is shown.

**Now:** type in "http://" and click into username field. See that the error messages are checking if the field contains http/https and shows the `Web address must have a valid hostname` error instead.

## Screenshots or Videos
<img width="325" alt="create_errors_http" src="https://user-images.githubusercontent.com/43795363/74787442-d1564f80-5274-11ea-84e0-6c6bb5304989.gif">


## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
