### PR TITLE
1167: Choose dialog button colors when view is constructed

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
@@ -44,7 +44,7 @@ sealed class DialogAction(
             R.string.disconnect_disclaimer_message,
             R.string.disconnect,
             R.string.cancel,
-            R.color.red
+            true
         ),
         listOf(LifecycleAction.UserReset)
     )
@@ -71,7 +71,7 @@ sealed class DialogAction(
             R.string.delete_description,
             R.string.delete,
             R.string.cancel,
-            R.color.red
+            true
         ),
         listOf(
             DataStoreAction.Delete(item),
@@ -102,7 +102,7 @@ sealed class DialogAction(
             R.string.discard_changes_description,
             R.string.discard,
             R.string.cancel,
-            R.color.red
+            true
         ),
         listOf(
             ItemDetailAction.EndEditItemSession
@@ -115,7 +115,7 @@ sealed class DialogAction(
             R.string.discard_changes_description,
             R.string.discard,
             R.string.cancel,
-            R.color.red
+            true
         ),
         listOf(
             DiscardCreateItemNoChanges

--- a/app/src/main/java/mozilla/lockbox/extensions/view/AlertDialog+.kt
+++ b/app/src/main/java/mozilla/lockbox/extensions/view/AlertDialog+.kt
@@ -68,9 +68,10 @@ object AlertDialogHelper {
 
         dialog.show()
 
-        viewModel.positiveButtonColor?.let {
-            dialog.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(context.getColor(it))
-        } ?: run {
+        if (viewModel.isDestructive) {
+            val destructiveColor = context.getColor(R.color.red)
+            dialog.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(destructiveColor)
+        } else {
             dialog.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(defaultColor)
         }
         dialog.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(defaultColor)

--- a/app/src/main/java/mozilla/lockbox/model/DialogViewModel.kt
+++ b/app/src/main/java/mozilla/lockbox/model/DialogViewModel.kt
@@ -14,5 +14,5 @@ data class DialogViewModel(
     @StringRes val message: Int? = null,
     @StringRes val positiveButtonTitle: Int? = null,
     @StringRes val negativeButtonTitle: Int? = null,
-    @ColorRes val positiveButtonColor: Int? = null
+    val isDestructive: Boolean = false
 )

--- a/app/src/main/java/mozilla/lockbox/model/DialogViewModel.kt
+++ b/app/src/main/java/mozilla/lockbox/model/DialogViewModel.kt
@@ -6,7 +6,6 @@
 
 package mozilla.lockbox.model
 
-import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 
 data class DialogViewModel(


### PR DESCRIPTION
Fixes #1167





## Testing and Review Notes

When creating a `DialogViewModel`, an optional `Boolean` can be passed in to describe whether or not the positive button action is destructive or not. If set to `true`, the positive button color will be `R.color.red`. If set to `false` (either explicitly or by default), the color will be `R.color.violet_70`.

All previous usages of setting a color resource on a `DialogViewModel` should be changed to `true` (a destructive red is the only color currently being set). The actual usage of the color resource was moved to be alongside the rest of the dialog UI definitions. No other colors are currently being used for this button and the `isDestructive` property will default to `false` if not specified.

The UI should remain the same for all previously existing `DialogAction`s. 
Non-destructive dialogs (ex: `SecurityDisclaimer` and `OnboardingSecurityDialogAutomatic`) should still have the same `R.color.violet_70` positive button color, and destructive dialogs (ex: `DeleteConfirmationDialog` and `DiscardChangesDialog`) should still have `R.color.red` for their positive buttons.






## Screenshots or Videos

![Screenshot_1585006126](https://user-images.githubusercontent.com/16379504/77375390-b7ac9a00-6d43-11ea-9de2-21afee07246d.png)
![Screenshot_1585006245](https://user-images.githubusercontent.com/16379504/77375392-b8453080-6d43-11ea-918a-cdac244a6e3e.png)

Here's two examples of a destructive and non-destructive dialog. Let me know if you need pictures for the rest of the dialogs.

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI


## Miscellaneous concerns
I did not notice any unit or instrumentation tests for `DialogViewModel`, `DialogAction`, or etcetera for the button colors, title strings and such. Are tests not needed for these files or functionality? I have not created tests yet, but will do so if needed. There were also two unit tests failing in the current master branch that I ignored for now.

Using a Boolean like this would only allow for two colors. Are there plans to add more color options, or should this be converted into something like an enum to support more colors?
