### PR TITLE
Closes #1219: fixes a 'null' toast on autofill failure on Android 11

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven2" />
+      <option name="name" value="maven2" />
+      <option name="url" value="https://maven.mozilla.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://snapshots.maven.mozilla.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+  </component>
+</project>


### PR DESCRIPTION
Fixes #1219


## Testing and Review Notes

- Use device running Android 11 (I was unable to repro on emulator)
- Install master Lockwise
- Set Lockwise as autofill provider
- Close and open Play Store app
- Select search bar at top of screen
--> EXPECT toast with text "null"
- Install `1219-fix-null-toast` Lockwise
- Close and open Play Store app
- Select search bar at top of screen
--> EXPECT no toast

## Screenshots or Videos

### master
<img src="https://user-images.githubusercontent.com/13170306/93821701-c9e49380-fc13-11ea-8289-262cc017fd6f.gif" height="600px"/>

### 1219 fix
<img src="https://user-images.githubusercontent.com/13170306/93821718-d0730b00-fc13-11ea-84f4-1b7fcbd0a55e.gif" height="600px"/>

## To Do

- [X] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [X] double check the original issue to confirm it is fully satisfied
- [X] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - Unfeasible
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
  - Not applicable, no UI changes
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [X] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
  - None
