### PR TITLE
Increase version number to 4.0.2 and update release notes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
         minSdkVersion 24
         //noinspection OldTargetApi
         targetSdkVersion 28
-        versionCode 6347
-        versionName "4.0.1"
+        versionCode 6460
+        versionName "4.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 4.0.2 (Build 6460)
+
+Adds a fix for an autofill failure on Android 11.
+
+Changes since last build:
+
+- Fixes a 'null' toast on autofill failure on Android 11 (#1219)
+
 ## 4.0.1 (Build 6347)
 
 Add the ability for users to control their tracked telemetry (linked through legacy telemetry client id) and prevent any further telemetry from being tracked for their account when they opt out.


### PR DESCRIPTION
# Release Notes

## 4.0.2 (Build 6460)

Adds a fix for an autofill failure on Android 11.

Changes since last build:

- Fixes a 'null' toast on autofill failure on Android 11 (#1219)
