### PR TITLE
Fix typo in “On Using Keys and Biometrics” page

### DIFF
--- a/docs/architecture/sec-apis.md
+++ b/docs/architecture/sec-apis.md
@@ -10,7 +10,7 @@ Below are some findings on using a couple of security features in Android:
 
 The `AndroidKeyStore` is an implementation of the [Java Cryptography Architecture (JCA)](https://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html)'s `KeyStore` service to manage application-specific cryptographic keys.  Such keys can be created or imported with an associated label, then an opaque `Key` class obtained from that label to use for cryptographic operations.  However, they **cannot** be exported.  The remainder here focuses on creating rather than import.
 
-Obtaining this Keystore is done using the static method `Keystore.getIstance()` and specifying the "AndroidKeyStore" Service Provider Interface (SPI) provider.
+Obtaining this Keystore is done using the static method `Keystore.getInstance()` and specifying the "AndroidKeyStore" Service Provider Interface (SPI) provider.
 
 New keys are created using an instance of `KeyGenerator` (or `KeyPairGenerator`), again specifying "AndroidKeyStore" as the SPI provider.  When creating a new key, several properties can be applied via `KeyGenParameterSpec`, including:
 


### PR DESCRIPTION
Fixes #1269 (typo in Markdown docs)

_(**Required**: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request.)_

https://github.com/mozilla-lockwise/lockwise-android/blob/master/docs/architecture/sec-apis.md


## Testing and Review Notes

I have confirmed that the revised Markdown does not contain the typo


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockwise.github.io/lockwise-android/accessibility/) of any added UI
